### PR TITLE
Enable query context sharing

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,7 +23,12 @@ function patchRainbowKitFooterLink() {
 
 patchRainbowKitFooterLink();
 
-const queryClient = new QueryClient();
+// Enable context sharing so that multiple QueryClientProvider instances can
+// share the same QueryClient across React roots. This helps avoid duplicated
+// caches when using microfrontends or embedding the app elsewhere.
+const queryClient = new QueryClient({
+  contextSharing: true,
+});
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- enable `contextSharing` when creating the react-query `QueryClient`

## Testing
- `npm run lint` *(fails: `eslint` not found)*
- `npx vitest run` *(fails: cannot reach npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_6881250d3798832d8dcce5d1a3db588d