### PR TITLE
Implement header/footer and wallet hook

### DIFF
--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -1,0 +1,7 @@
+import { useAccount } from 'wagmi';
+import { Wallet } from '../types/wallet';
+
+export function useWallet(): Wallet {
+  const { address, isConnected } = useAccount();
+  return { address: address ?? '', isConnected };
+}

--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Footer() {
+  return (
+    <footer className="p-4 border-t text-center text-xs text-gray-500 bg-white">
+      © 2024 SendFIL
+    </footer>
+  );
+}

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Header() {
+  return (
+    <header className="p-4 border-b bg-white">
+      <h1 className="text-lg font-semibold">SendFIL</h1>
+    </header>
+  );
+}

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -1,0 +1,4 @@
+export interface Wallet {
+  address: string;
+  isConnected: boolean;
+}


### PR DESCRIPTION
## Summary
- add simple Header and Footer components
- define a basic Wallet interface
- implement a useWallet hook that exposes wagmi account data

## Testing
- `npm run lint` *(fails: Invalid option '--ext' with eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_6881351ef9ec832dab2c4cdecd995e6e