### PR TITLE
feat: unify recipient validation guardrails

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,18 +10,23 @@ import ReviewTransactionModal, {
   TransactionState,
   GasEstimate,
 } from './components/ReviewTransactionModal';
-import { useAccount, useBalance } from 'wagmi';
+import { useAccount, useBalance, useChainId } from 'wagmi';
 import { calculateFeeRows } from './utils/fee';
 import { buildBatchTransaction, attoFilToFil } from './lib/transaction/messageBuilder';
 import { getNonce } from './lib/DataProvider';
+import { validateRecipientRows } from './utils/recipientValidation';
 
 interface Recipient {
   address: string;
   amount: string;
 }
 
+const FILECOIN_MAINNET_ID = 314;
+const MAINNET_ADDRESS_PREFIX = 'f' as const;
+
 export default function App() {
   const { isConnected, address } = useAccount();
+  const chainId = useChainId();
   const { data: balanceData } = useBalance({ address });
   const [recipients, setRecipients] = React.useState<Recipient[]>([]);
   const [csvData, setCsvData] = React.useState<CSVRecipient[]>([]);
@@ -63,7 +68,10 @@ export default function App() {
         amount: csvRecipient.value,
       }));
       setRecipients(convertedRecipients);
+      return;
     }
+
+    setRecipients([]);
   };
 
   const handleCSVReset = () => {
@@ -88,10 +96,49 @@ export default function App() {
     setRecipients(newRecipients);
   };
 
+  const manualValidation = React.useMemo(
+    () =>
+      validateRecipientRows(recipients, {
+        source: 'manual',
+        expectedNetworkPrefix: MAINNET_ADDRESS_PREFIX,
+        requireAtLeastOneRecipient: false,
+      }),
+    [recipients],
+  );
+
+  const hasEnteredData = showManualInput
+    ? manualValidation.nonEmptyRowCount > 0
+    : recipients.length > 0 || csvErrors.length > 0 || csvWarnings.length > 0;
+  const isNetworkMismatch = isConnected && chainId !== FILECOIN_MAINNET_ID;
+  const networkValidationErrors = isNetworkMismatch
+    && hasEnteredData
+    ? ['Switch to Filecoin Mainnet (chain 314) to review and send this batch.']
+    : [];
+
+  const activeValidationErrors = showManualInput
+    ? [...manualValidation.errors, ...networkValidationErrors]
+    : [...csvErrors, ...networkValidationErrors];
+  const activeValidationWarnings = showManualInput ? manualValidation.warnings : csvWarnings;
+
   // Calculate fee and totals for the modal
-  const validRecipients = recipients
-    .filter((r) => r.address && r.amount)
-    .map((r) => ({ address: r.address, amount: Number(r.amount) }));
+  const validRecipients = React.useMemo(
+    () =>
+      (showManualInput
+        ? manualValidation.validRecipients
+        : recipients.map((recipient, index) => ({
+            ...recipient,
+            lineNumber: index + 1,
+          }))
+      ).map((recipient) => ({
+        address: recipient.address,
+        amount: Number(recipient.amount),
+      })),
+    [manualValidation.validRecipients, recipients, showManualInput],
+  );
+
+  const hasReviewableRows = showManualInput
+    ? manualValidation.nonEmptyRowCount > 0
+    : recipients.length > 0;
 
   const recipientTotal = validRecipients.reduce((sum, r) => sum + r.amount, 0);
 
@@ -112,7 +159,11 @@ export default function App() {
   const insufficientBalance = walletBalance < recipientTotal + feeTotal + estimatedNetworkFee;
 
   const handleReview = async () => {
-    if (validRecipients.length === 0) {
+    if (isNetworkMismatch) {
+      return;
+    }
+
+    if (!hasReviewableRows) {
       alert('Please add at least one recipient');
       return;
     }
@@ -126,7 +177,7 @@ export default function App() {
     setIsReviewModalOpen(true);
 
     // Start gas estimation
-    if (address) {
+    if (address && validRecipients.length > 0 && activeValidationErrors.length === 0) {
       setIsEstimatingGas(true);
       try {
         // Get all recipients including fee rows
@@ -324,28 +375,29 @@ f1cj...,3.3`;
                       <CSVUpload
                         onUpload={handleCSVUpload}
                         disabled={false}
+                        expectedNetworkPrefix={MAINNET_ADDRESS_PREFIX}
                       />
                     </div>
                   )}
 
                   {/* CSV Validation Messages */}
-                  {(csvErrors.length > 0 || csvWarnings.length > 0) && (
+                  {(activeValidationErrors.length > 0 || activeValidationWarnings.length > 0) && (
                     <div className="mb-6 space-y-2">
-                      {csvErrors.length > 0 && (
+                      {activeValidationErrors.length > 0 && (
                         <div className="bg-red-50 border border-red-200 rounded-md p-4">
                           <h4 className="font-semibold text-red-800 mb-2">Errors:</h4>
                           <ul className="text-sm text-red-700 space-y-1">
-                            {csvErrors.map((error, index) => (
+                            {activeValidationErrors.map((error, index) => (
                               <li key={index}>• {error}</li>
                             ))}
                           </ul>
                         </div>
                       )}
-                      {csvWarnings.length > 0 && (
+                      {activeValidationWarnings.length > 0 && (
                         <div className="bg-yellow-50 border border-yellow-200 rounded-md p-4">
                           <h4 className="font-semibold text-yellow-800 mb-2">Warnings:</h4>
                           <ul className="text-sm text-yellow-700 space-y-1">
-                            {csvWarnings.map((warning, index) => (
+                            {activeValidationWarnings.map((warning, index) => (
                               <li key={index}>• {warning}</li>
                             ))}
                           </ul>
@@ -406,7 +458,8 @@ f1cj...,3.3`;
                                   </div>
                                   <div className="relative flex items-center gap-2">
                                     <input
-                                      type="number"
+                                      type="text"
+                                      inputMode="decimal"
                                       placeholder="0"
                                       value={recipient.amount}
                                       onChange={(e) =>
@@ -450,15 +503,26 @@ f1cj...,3.3`;
                     </>
                   )}
 
-                  {/* Review Button - only show when we have valid recipients */}
-                  {recipients.length > 0 && csvErrors.length === 0 && (
+                  {/* Review Button - only show when we have entered recipients */}
+                  {hasReviewableRows && (
                     <div className="mt-6">
                       <button
-                        className="w-full text-white bg-blue-500 hover:bg-blue-600 rounded-md py-3 px-4 font-medium text-lg"
+                        className={`w-full rounded-md py-3 px-4 font-medium text-lg ${
+                          isNetworkMismatch
+                            ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                            : 'text-white bg-blue-500 hover:bg-blue-600'
+                        }`}
                         onClick={handleReview}
+                        disabled={isNetworkMismatch}
                       >
-                        Review Batch ({recipients.length} recipients)
+                        Review Batch (
+                        {showManualInput ? manualValidation.nonEmptyRowCount : recipients.length} recipients)
                       </button>
+                      {isNetworkMismatch && (
+                        <p className="mt-2 text-sm text-red-700">
+                          Switch to Filecoin Mainnet before reviewing or sending this batch.
+                        </p>
+                      )}
                     </div>
                   )}
                 </>
@@ -486,8 +550,8 @@ f1cj...,3.3`;
         onClose={handleCloseReviewModal}
         onConfirm={handleConfirmTransaction}
         recipients={validRecipients}
-        validationErrors={csvErrors}
-        validationWarnings={csvWarnings}
+        validationErrors={activeValidationErrors}
+        validationWarnings={activeValidationWarnings}
         recipientTotal={recipientTotal}
         feeTotal={feeTotal}
         gasEstimate={gasEstimate}

--- a/src/components/CSVUpload.tsx
+++ b/src/components/CSVUpload.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import Papa, { type ParseResult } from 'papaparse';
+import { validateRecipientRows } from '../utils/recipientValidation';
 
 export interface CSVRecipient {
   receiverAddress: string;
@@ -16,33 +17,16 @@ export interface CSVUploadResult {
 interface CSVUploadProps {
   onUpload: (result: CSVUploadResult) => void;
   disabled?: boolean;
+  expectedNetworkPrefix?: 'f' | 't';
 }
 
-export const CSVUpload: React.FC<CSVUploadProps> = ({ onUpload, disabled = false }) => {
+export const CSVUpload: React.FC<CSVUploadProps> = ({
+  onUpload,
+  disabled = false,
+  expectedNetworkPrefix = 'f',
+}) => {
   const [isDragOver, setIsDragOver] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
-
-  const validateAddress = (address: string): boolean => {
-    // Basic Filecoin address validation
-    if (!address || typeof address !== 'string') return false;
-
-    // Check for f1, f2, f3, f4, t1, t2, t3, t4 addresses
-    const filecoinAddressRegex = /^[ft][0-4][a-zA-Z0-9]{38,}$/;
-    return filecoinAddressRegex.test(address.trim());
-  };
-
-  const validateValue = (value: string): { isValid: boolean; numericValue?: number } => {
-    if (!value || typeof value !== 'string') return { isValid: false };
-
-    const trimmed = value.trim();
-    const numericValue = parseFloat(trimmed);
-
-    if (isNaN(numericValue) || numericValue <= 0) {
-      return { isValid: false };
-    }
-
-    return { isValid: true, numericValue };
-  };
 
   const processCSV = useCallback(
     async (file: File) => {
@@ -56,10 +40,8 @@ export const CSVUpload: React.FC<CSVUploadProps> = ({ onUpload, disabled = false
           skipEmptyLines: true,
           transformHeader: (header: string) => header.trim().toLowerCase(),
           complete: (results: ParseResult<Record<string, string>>) => {
-            const recipients: CSVRecipient[] = [];
+            const parsedRecipients: CSVRecipient[] = [];
             const errors: string[] = [];
-            const warnings: string[] = [];
-            const seenAddresses = new Set<string>();
 
             // Check for required columns
             const headers = results.meta.fields || [];
@@ -94,51 +76,44 @@ export const CSVUpload: React.FC<CSVUploadProps> = ({ onUpload, disabled = false
                 const address = addressKey ? row[addressKey]?.trim() || '' : '';
                 const value = valueKey ? row[valueKey]?.trim() || '' : '';
 
-                // Skip empty rows
-                if (!address && !value) return;
-
-                // Validate address
-                if (!validateAddress(address)) {
-                  errors.push(`Line ${lineNumber}: Invalid Filecoin address "${address}"`);
-                  return;
-                }
-
-                // Check for duplicates
-                if (seenAddresses.has(address)) {
-                  warnings.push(`Line ${lineNumber}: Duplicate address "${address}"`);
-                } else {
-                  seenAddresses.add(address);
-                }
-
-                // Validate value
-                const valueValidation = validateValue(value);
-                if (!valueValidation.isValid) {
-                  errors.push(
-                    `Line ${lineNumber}: Invalid value "${value}" (must be positive number)`,
-                  );
-                  return;
-                }
-
-                recipients.push({
+                parsedRecipients.push({
                   receiverAddress: address,
-                  value: value,
+                  value,
                   lineNumber,
                 });
               });
             }
 
-            // Additional validations
-            if (recipients.length === 0 && errors.length === 0) {
-              errors.push('No valid recipients found in CSV file');
-            }
+            const validationResult =
+              errors.length === 0
+                ? validateRecipientRows(
+                    parsedRecipients.map((recipient) => ({
+                      address: recipient.receiverAddress,
+                      amount: recipient.value,
+                      lineNumber: recipient.lineNumber,
+                    })),
+                    {
+                      source: 'csv',
+                      expectedNetworkPrefix,
+                      requireAtLeastOneRecipient: true,
+                    },
+                  )
+                : {
+                    validRecipients: [],
+                    errors: [],
+                    warnings: [],
+                    nonEmptyRowCount: 0,
+                  };
 
-            if (recipients.length > 1000) {
-              warnings.push(
-                `Large batch detected: ${recipients.length} recipients. Consider splitting into smaller batches.`,
-              );
-            }
-
-            onUpload({ recipients, errors, warnings });
+            onUpload({
+              recipients: validationResult.validRecipients.map((recipient) => ({
+                receiverAddress: recipient.address,
+                value: recipient.amount,
+                lineNumber: recipient.lineNumber,
+              })),
+              errors: [...errors, ...validationResult.errors],
+              warnings: validationResult.warnings,
+            });
             setIsProcessing(false);
           },
           error: (error: Error) => {
@@ -161,7 +136,7 @@ export const CSVUpload: React.FC<CSVUploadProps> = ({ onUpload, disabled = false
         setIsProcessing(false);
       }
     },
-    [onUpload],
+    [expectedNetworkPrefix, onUpload],
   );
 
   const handleDrop = useCallback(

--- a/src/components/ReviewTransactionModal.tsx
+++ b/src/components/ReviewTransactionModal.tsx
@@ -275,10 +275,7 @@ export const ReviewTransactionModal: React.FC<ReviewTransactionModalProps> = ({
         >
           <span className="flex items-center gap-2">
             {validationErrors.length > 0 ? (
-              <span className="text-yellow-600">
-                {recipients.length - validationErrors.length} of {recipients.length} recipients
-                valid
-              </span>
+              <span className="text-yellow-600">{recipients.length} recipients currently valid</span>
             ) : (
               <span className="text-green-600">✓ {recipients.length} recipients validated</span>
             )}

--- a/src/utils/__tests__/recipientValidation.test.ts
+++ b/src/utils/__tests__/recipientValidation.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { validateRecipientRows } from '../recipientValidation';
+import { toF4 } from '../toF4';
+
+describe('validateRecipientRows', () => {
+  it('accepts supported mainnet address types including 0x recipients', () => {
+    const result = validateRecipientRows(
+      [
+        {
+          address: 'f1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za',
+          amount: '1.25',
+        },
+        {
+          address: 'f410fdjztlgqlzfda5hm6bm6z5gt3aglxcfsu24pgrsi',
+          amount: '2',
+        },
+        {
+          address: '0x1234567890abcdef1234567890abcdef12345678',
+          amount: '0.5',
+        },
+      ],
+      { source: 'manual', expectedNetworkPrefix: 'f' },
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.validRecipients).toHaveLength(3);
+    expect(result.validRecipients[2]?.address).toBe(
+      '0x1234567890AbcdEF1234567890aBcdef12345678',
+    );
+  });
+
+  it('rejects f0 recipients', () => {
+    const result = validateRecipientRows(
+      [{ address: 'f01234', amount: '1' }],
+      { source: 'manual', expectedNetworkPrefix: 'f' },
+    );
+
+    expect(result.errors).toEqual([
+      'Recipient 1: f0/t0 ID addresses are not supported',
+    ]);
+  });
+
+  it('rejects testnet prefixes in the mainnet flow', () => {
+    const result = validateRecipientRows(
+      [
+        {
+          address: 't1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za',
+          amount: '1',
+        },
+      ],
+      { source: 'csv', expectedNetworkPrefix: 'f' },
+    );
+
+    expect(result.errors).toEqual([
+      'Line 1: t1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za does not match the current mainnet address format',
+    ]);
+  });
+
+  it('warns when duplicate recipients resolve to the same EVM destination', () => {
+    const result = validateRecipientRows(
+      [
+        {
+          address: '0xe764Acf02D8B7c21d2B6A8f0a96C78541e0DC3fd',
+          amount: '1',
+        },
+        {
+          address: toF4('0xe764Acf02D8B7c21d2B6A8f0a96C78541e0DC3fd', 'f'),
+          amount: '2',
+        },
+      ],
+      { source: 'manual', expectedNetworkPrefix: 'f' },
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([
+      'Recipient 2: Duplicate recipient matches Recipient 1',
+    ]);
+  });
+
+  it('rejects malformed amounts and values over 18 decimals', () => {
+    const result = validateRecipientRows(
+      [
+        {
+          address: 'f1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za',
+          amount: '1.1234567890123456789',
+        },
+        {
+          address: 'f1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za',
+          amount: '10 FIL',
+        },
+      ],
+      { source: 'manual', expectedNetworkPrefix: 'f' },
+    );
+
+    expect(result.errors).toEqual([
+      'Recipient 1: Amount must be a positive FIL value with up to 18 decimal places',
+      'Recipient 2: Amount must be a positive FIL value with up to 18 decimal places',
+    ]);
+  });
+
+  it('enforces the 500 recipient cap', () => {
+    const rows = Array.from({ length: 501 }, () => ({
+      address: 'f1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za',
+      amount: '1',
+    }));
+
+    const result = validateRecipientRows(rows, {
+      source: 'manual',
+      expectedNetworkPrefix: 'f',
+    });
+
+    expect(result.errors).toContain(
+      'Batch size exceeds the current limit of 500 recipients',
+    );
+  });
+});

--- a/src/utils/recipientValidation.ts
+++ b/src/utils/recipientValidation.ts
@@ -1,0 +1,244 @@
+import { newFromString } from '@glif/filecoin-address';
+import { getAddress, isAddress } from 'viem';
+import { normalizeToEvmAddress } from './addressEncoder';
+
+export interface RecipientInput {
+  address: string;
+  amount: string;
+  lineNumber?: number;
+}
+
+export interface ValidatedRecipient extends RecipientInput {
+  lineNumber: number;
+}
+
+export interface RecipientValidationOptions {
+  source: 'csv' | 'manual';
+  expectedNetworkPrefix?: 'f' | 't';
+  maxRecipients?: number;
+  requireAtLeastOneRecipient?: boolean;
+}
+
+export interface RecipientValidationResult {
+  validRecipients: ValidatedRecipient[];
+  errors: string[];
+  warnings: string[];
+  nonEmptyRowCount: number;
+}
+
+interface AddressValidationResult {
+  isValid: boolean;
+  normalizedAddress?: string;
+  duplicateKey?: string;
+  error?: string;
+}
+
+interface AmountValidationResult {
+  isValid: boolean;
+  normalizedAmount?: string;
+  error?: string;
+}
+
+const DEFAULT_MAX_RECIPIENTS = 500;
+
+function normalizeEvmInput(address: string): `0x${string}` | null {
+  if (!/^0x/i.test(address)) {
+    return null;
+  }
+
+  const normalizedPrefixAddress = `0x${address.slice(2)}`;
+  if (!isAddress(normalizedPrefixAddress)) {
+    return null;
+  }
+
+  return getAddress(normalizedPrefixAddress);
+}
+
+function getRowLabel(
+  source: RecipientValidationOptions['source'],
+  lineNumber: number,
+): string {
+  return source === 'csv' ? `Line ${lineNumber}` : `Recipient ${lineNumber}`;
+}
+
+function toAttoFil(amount: string): bigint {
+  const [whole, decimal = ''] = amount.split('.');
+  const paddedDecimal = decimal.padEnd(18, '0');
+  return BigInt(`${whole}${paddedDecimal}`);
+}
+
+function validateAmount(amount: string): AmountValidationResult {
+  const trimmed = amount.trim();
+
+  if (!trimmed) {
+    return {
+      isValid: false,
+      error: 'Amount is required',
+    };
+  }
+
+  if (!/^\d+(?:\.\d{1,18})?$/.test(trimmed)) {
+    return {
+      isValid: false,
+      error: 'Amount must be a positive FIL value with up to 18 decimal places',
+    };
+  }
+
+  if (toAttoFil(trimmed) <= 0n) {
+    return {
+      isValid: false,
+      error: 'Amount must be greater than 0',
+    };
+  }
+
+  return {
+    isValid: true,
+    normalizedAmount: trimmed,
+  };
+}
+
+function validateAddress(
+  address: string,
+  expectedNetworkPrefix?: 'f' | 't',
+): AddressValidationResult {
+  const trimmed = address.trim();
+
+  if (!trimmed) {
+    return {
+      isValid: false,
+      error: 'Address is required',
+    };
+  }
+
+  const normalizedEvmAddress = normalizeEvmInput(trimmed);
+  if (normalizedEvmAddress) {
+    return {
+      isValid: true,
+      normalizedAddress: normalizedEvmAddress,
+      duplicateKey: normalizedEvmAddress.toLowerCase(),
+    };
+  }
+
+  try {
+    newFromString(trimmed);
+  } catch {
+    return {
+      isValid: false,
+      error: `Invalid address "${trimmed}"`,
+    };
+  }
+
+  if (/^[ft]0/.test(trimmed)) {
+    return {
+      isValid: false,
+      error: 'f0/t0 ID addresses are not supported',
+    };
+  }
+
+  if (!/^[ft][1234]/.test(trimmed)) {
+    return {
+      isValid: false,
+      error: `Unsupported address format "${trimmed}"`,
+    };
+  }
+
+  if (expectedNetworkPrefix && trimmed[0] !== expectedNetworkPrefix) {
+    const networkLabel = expectedNetworkPrefix === 'f' ? 'mainnet' : 'Calibration';
+    return {
+      isValid: false,
+      error: `${trimmed} does not match the current ${networkLabel} address format`,
+    };
+  }
+
+  const normalizedTwin = normalizeToEvmAddress(trimmed);
+
+  return {
+    isValid: true,
+    normalizedAddress: trimmed,
+    duplicateKey: normalizedTwin ? normalizedTwin.toLowerCase() : trimmed,
+  };
+}
+
+export function validateRecipientRows(
+  rows: RecipientInput[],
+  options: RecipientValidationOptions,
+): RecipientValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const validRecipients: ValidatedRecipient[] = [];
+  const seenRecipients = new Map<string, string>();
+  const maxRecipients = options.maxRecipients ?? DEFAULT_MAX_RECIPIENTS;
+  const requireAtLeastOneRecipient = options.requireAtLeastOneRecipient ?? true;
+  let nonEmptyRowCount = 0;
+
+  rows.forEach((row, index) => {
+    const lineNumber = row.lineNumber ?? index + 1;
+    const rowLabel = getRowLabel(options.source, lineNumber);
+    const address = row.address.trim();
+    const amount = row.amount.trim();
+
+    if (!address && !amount) {
+      return;
+    }
+
+    nonEmptyRowCount += 1;
+
+    if (!address) {
+      errors.push(`${rowLabel}: Address is required`);
+      return;
+    }
+
+    if (!amount) {
+      errors.push(`${rowLabel}: Amount is required`);
+      return;
+    }
+
+    const addressValidation = validateAddress(address, options.expectedNetworkPrefix);
+    if (!addressValidation.isValid || !addressValidation.normalizedAddress) {
+      errors.push(`${rowLabel}: ${addressValidation.error}`);
+      return;
+    }
+
+    const amountValidation = validateAmount(amount);
+    if (!amountValidation.isValid || !amountValidation.normalizedAmount) {
+      errors.push(`${rowLabel}: ${amountValidation.error}`);
+      return;
+    }
+
+    const duplicateSource = seenRecipients.get(addressValidation.duplicateKey!);
+    if (duplicateSource) {
+      warnings.push(
+        `${rowLabel}: Duplicate recipient matches ${duplicateSource}`,
+      );
+    } else {
+      seenRecipients.set(addressValidation.duplicateKey!, rowLabel);
+    }
+
+    validRecipients.push({
+      address: addressValidation.normalizedAddress,
+      amount: amountValidation.normalizedAmount,
+      lineNumber,
+    });
+  });
+
+  if (requireAtLeastOneRecipient && nonEmptyRowCount === 0) {
+    errors.push(
+      options.source === 'csv'
+        ? 'No recipients found in CSV file'
+        : 'Add at least one recipient to continue',
+    );
+  }
+
+  if (nonEmptyRowCount > maxRecipients) {
+    errors.push(
+      `Batch size exceeds the current limit of ${maxRecipients} recipients`,
+    );
+  }
+
+  return {
+    validRecipients,
+    errors,
+    warnings,
+    nonEmptyRowCount,
+  };
+}


### PR DESCRIPTION
## Summary
- unify recipient validation across CSV and manual entry
- add mainnet guardrails for address/network mismatches and 500-row limits
- cover the new validation rules with tests

## Testing
- yarn test
- yarn lint
- yarn typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect the core pre-send validation and gating logic; mistakes could block valid batches or allow invalid recipients through to transaction building.
> 
> **Overview**
> Unifies recipient validation for both CSV uploads and manual entry via new `validateRecipientRows`, adding consistent checks for address format (including `0x`), network prefix mismatches, amount formatting (up to 18 decimals), duplicate detection (including EVM-equivalent addresses), and a 500-recipient cap.
> 
> Updates the send flow UI to surface a single set of active errors/warnings, disables review/sending on Filecoin network mismatch (chain `314`), and gates gas estimation/review on passing validation; adds unit tests covering the new validation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94471aef9b073b638aacc11803b99e88b05fb337. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->