### PR TITLE
feat: require duplicate confirmation at review

### DIFF
--- a/src/components/ReviewTransactionModal.tsx
+++ b/src/components/ReviewTransactionModal.tsx
@@ -1,5 +1,9 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useChainId } from 'wagmi';
+import {
+  getDuplicateRecipientWarnings,
+  isDuplicateRecipientWarning,
+} from '../utils/recipientValidation';
 
 export type TransactionState = 'review' | 'signing' | 'pending' | 'confirmed' | 'failed';
 
@@ -80,6 +84,8 @@ export const ReviewTransactionModal: React.FC<ReviewTransactionModalProps> = ({
   const [showDetails, setShowDetails] = useState(false);
   const [showGasDetails, setShowGasDetails] = useState(false);
   const [showFeeTooltip, setShowFeeTooltip] = useState(false);
+  const [hasAcknowledgedDuplicateRecipients, setHasAcknowledgedDuplicateRecipients] =
+    useState(false);
   const modalRef = useRef<HTMLDivElement>(null);
   const chainId = useChainId();
 
@@ -100,10 +106,17 @@ export const ReviewTransactionModal: React.FC<ReviewTransactionModalProps> = ({
   // Calculate totals
   const estimatedNetworkFee = gasEstimate?.estimatedFeeInFil || 0;
   const grandTotal = recipientTotal + feeTotal + estimatedNetworkFee;
+  const duplicateRecipientWarnings = getDuplicateRecipientWarnings(validationWarnings);
+  const otherValidationWarnings = validationWarnings.filter(
+    (warning) => !isDuplicateRecipientWarning(warning),
+  );
+  const duplicateWarningsSignature = duplicateRecipientWarnings.join('|');
+  const requiresDuplicateConfirmation = duplicateRecipientWarnings.length > 0;
 
   // Send button should be disabled when:
   const isSendDisabled =
     validationErrors.length > 0 ||
+    (requiresDuplicateConfirmation && !hasAcknowledgedDuplicateRecipients) ||
     insufficientBalance ||
     isEstimatingGas ||
     transactionState !== 'review';
@@ -135,6 +148,10 @@ export const ReviewTransactionModal: React.FC<ReviewTransactionModalProps> = ({
     }
   }, [isOpen]);
 
+  useEffect(() => {
+    setHasAcknowledgedDuplicateRecipients(false);
+  }, [duplicateWarningsSignature, isOpen]);
+
   if (!isOpen) return null;
 
   // Render different states
@@ -157,11 +174,43 @@ export const ReviewTransactionModal: React.FC<ReviewTransactionModalProps> = ({
       )}
 
       {/* Warnings Section */}
-      {validationWarnings.length > 0 && validationErrors.length === 0 && (
+      {duplicateRecipientWarnings.length > 0 && (
+        <div className="mb-4 bg-amber-50 border border-amber-200 rounded-md p-4">
+          <h4 className="font-semibold text-amber-900 mb-2">
+            Duplicate recipients need confirmation
+          </h4>
+          <p className="text-sm text-amber-800 mb-3">
+            This batch includes duplicate recipients. SendFIL will treat each duplicate entry as a
+            separate transfer.
+          </p>
+          <ul className="text-sm text-amber-800 space-y-1">
+            {duplicateRecipientWarnings.map((warning, index) => (
+              <li key={index}>• {warning}</li>
+            ))}
+          </ul>
+          <label className="mt-3 flex items-start gap-3 text-sm text-amber-900">
+            <input
+              type="checkbox"
+              className="mt-1 h-4 w-4 rounded border-amber-300 text-blue-600 focus:ring-blue-500"
+              checked={hasAcknowledgedDuplicateRecipients}
+              onChange={(event) => setHasAcknowledgedDuplicateRecipients(event.target.checked)}
+              aria-label="Acknowledge duplicate recipients"
+            />
+            <span>
+              I understand the duplicate recipients above will each receive a separate transfer.
+              <span className="block text-xs text-amber-700 mt-1">
+                Required before you can send this batch.
+              </span>
+            </span>
+          </label>
+        </div>
+      )}
+
+      {otherValidationWarnings.length > 0 && validationErrors.length === 0 && (
         <div className="mb-4 bg-yellow-50 border border-yellow-200 rounded-md p-4">
           <h4 className="font-semibold text-yellow-800 mb-2">Warnings:</h4>
           <ul className="text-sm text-yellow-700 space-y-1">
-            {validationWarnings.map((warning, index) => (
+            {otherValidationWarnings.map((warning, index) => (
               <li key={index}>• {warning}</li>
             ))}
           </ul>

--- a/src/components/__tests__/ReviewTransactionModal.test.tsx
+++ b/src/components/__tests__/ReviewTransactionModal.test.tsx
@@ -1,0 +1,165 @@
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { createRoot, type Root } from 'react-dom/client';
+import ReviewTransactionModal, {
+  type ReviewTransactionModalProps,
+} from '../ReviewTransactionModal';
+
+vi.mock('wagmi', () => ({
+  useChainId: () => 314,
+}));
+
+function getBaseProps(): ReviewTransactionModalProps {
+  return {
+    isOpen: true,
+    onClose: vi.fn(),
+    onConfirm: vi.fn().mockResolvedValue(undefined),
+    recipients: [{ address: 'f1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za', amount: 1 }],
+    validationErrors: [],
+    validationWarnings: [],
+    recipientTotal: 1,
+    feeTotal: 0.01,
+    gasEstimate: {
+      gasLimit: 1000,
+      gasFeeCap: '1',
+      gasPremium: '1',
+      estimatedFeeInFil: 0.001,
+    },
+    isEstimatingGas: false,
+    gasEstimationError: undefined,
+    walletBalance: 10,
+    insufficientBalance: false,
+    transactionState: 'review',
+    transactionHash: undefined,
+    transactionError: undefined,
+  };
+}
+
+function getButton(container: HTMLElement, label: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll('button')).find(
+    (candidate) => candidate.textContent?.trim() === label,
+  );
+
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Could not find button with label "${label}"`);
+  }
+
+  return button;
+}
+
+function click(element: HTMLElement) {
+  act(() => {
+    element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+}
+
+describe('ReviewTransactionModal', () => {
+  let dom: JSDOM;
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    dom = new JSDOM('<!doctype html><html><body></body></html>', {
+      url: 'http://localhost',
+    });
+
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('navigator', dom.window.navigator);
+    vi.stubGlobal('Node', dom.window.Node);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('HTMLButtonElement', dom.window.HTMLButtonElement);
+    vi.stubGlobal('HTMLInputElement', dom.window.HTMLInputElement);
+    vi.stubGlobal('Event', dom.window.Event);
+    vi.stubGlobal('MouseEvent', dom.window.MouseEvent);
+    vi.stubGlobal('KeyboardEvent', dom.window.KeyboardEvent);
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    dom.window.close();
+  });
+
+  it('requires duplicate acknowledgment before enabling send', () => {
+    const props = getBaseProps();
+    props.validationWarnings = ['Recipient 2: Duplicate recipient matches Recipient 1'];
+
+    act(() => {
+      root.render(<ReviewTransactionModal {...props} />);
+    });
+
+    const sendButton = getButton(container, 'Send');
+    const checkbox = container.querySelector(
+      'input[aria-label="Acknowledge duplicate recipients"]',
+    );
+
+    expect(checkbox).toBeInstanceOf(HTMLInputElement);
+    expect(sendButton.disabled).toBe(true);
+
+    click(checkbox as HTMLInputElement);
+
+    expect(sendButton.disabled).toBe(false);
+
+    click(sendButton);
+
+    expect(props.onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not require acknowledgment for non-duplicate warnings', () => {
+    const props = getBaseProps();
+    props.validationWarnings = ['Batch is large and may take longer to process'];
+
+    act(() => {
+      root.render(<ReviewTransactionModal {...props} />);
+    });
+
+    const sendButton = getButton(container, 'Send');
+    const checkbox = container.querySelector(
+      'input[aria-label="Acknowledge duplicate recipients"]',
+    );
+
+    expect(checkbox).toBeNull();
+    expect(sendButton.disabled).toBe(false);
+  });
+
+  it('resets duplicate acknowledgment when the modal reopens', () => {
+    const props = getBaseProps();
+    props.validationWarnings = ['Recipient 2: Duplicate recipient matches Recipient 1'];
+
+    act(() => {
+      root.render(<ReviewTransactionModal {...props} />);
+    });
+
+    const initialCheckbox = container.querySelector(
+      'input[aria-label="Acknowledge duplicate recipients"]',
+    );
+    click(initialCheckbox as HTMLInputElement);
+
+    expect(getButton(container, 'Send').disabled).toBe(false);
+
+    act(() => {
+      root.render(<ReviewTransactionModal {...props} isOpen={false} />);
+    });
+
+    act(() => {
+      root.render(<ReviewTransactionModal {...props} />);
+    });
+
+    const reopenedCheckbox = container.querySelector(
+      'input[aria-label="Acknowledge duplicate recipients"]',
+    ) as HTMLInputElement;
+
+    expect(reopenedCheckbox.checked).toBe(false);
+    expect(getButton(container, 'Send').disabled).toBe(true);
+  });
+});

--- a/src/types/jsdom.d.ts
+++ b/src/types/jsdom.d.ts
@@ -1,0 +1,9 @@
+declare module 'jsdom' {
+  export class JSDOM {
+    window: Window &
+      typeof globalThis & {
+        close(): void;
+      };
+    constructor(html?: string, options?: { url?: string });
+  }
+}

--- a/src/utils/recipientValidation.ts
+++ b/src/utils/recipientValidation.ts
@@ -26,6 +26,8 @@ export interface RecipientValidationResult {
   nonEmptyRowCount: number;
 }
 
+export const DUPLICATE_RECIPIENT_WARNING_MARKER = 'Duplicate recipient matches';
+
 interface AddressValidationResult {
   isValid: boolean;
   normalizedAddress?: string;
@@ -208,7 +210,7 @@ export function validateRecipientRows(
     const duplicateSource = seenRecipients.get(addressValidation.duplicateKey!);
     if (duplicateSource) {
       warnings.push(
-        `${rowLabel}: Duplicate recipient matches ${duplicateSource}`,
+        `${rowLabel}: ${DUPLICATE_RECIPIENT_WARNING_MARKER} ${duplicateSource}`,
       );
     } else {
       seenRecipients.set(addressValidation.duplicateKey!, rowLabel);
@@ -241,4 +243,12 @@ export function validateRecipientRows(
     warnings,
     nonEmptyRowCount,
   };
+}
+
+export function isDuplicateRecipientWarning(warning: string): boolean {
+  return warning.includes(DUPLICATE_RECIPIENT_WARNING_MARKER);
+}
+
+export function getDuplicateRecipientWarnings(warnings: string[]): string[] {
+  return warnings.filter(isDuplicateRecipientWarning);
 }


### PR DESCRIPTION
## Summary
- require explicit duplicate acknowledgment in the review modal before Send is enabled
- keep duplicate recipients as warnings while separating them from other warnings
- add modal coverage for duplicate acknowledgment gating and reset behavior

## Testing
- yarn test
- yarn lint
- yarn typecheck