### PR TITLE
[codex] Add batch configuration UI scaffolding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,12 +6,23 @@ import ReviewTransactionModal, {
   TransactionState,
   GasEstimate,
 } from './components/ReviewTransactionModal';
+import UnavailableCapabilityModal from './components/UnavailableCapabilityModal';
 import { useAccount, useBalance, useChainId } from 'wagmi';
 import { formatUnits } from 'viem';
 import { calculateFeeRows } from './utils/fee';
 import { buildBatchTransaction, attoFilToFil } from './lib/transaction/messageBuilder';
 import { getNonce } from './lib/DataProvider';
 import { validateRecipientRows } from './utils/recipientValidation';
+import {
+  DEFAULT_BATCH_CONFIGURATION,
+  getErrorHandlingLabel,
+  getExecutionMethodLabel,
+  getSenderWalletTypeLabel,
+  type BatchConfiguration,
+  type ErrorHandlingPreference,
+  type ExecutionMethod,
+  type SenderWalletType,
+} from './lib/batchConfiguration';
 
 interface Recipient {
   address: string;
@@ -21,6 +32,19 @@ interface Recipient {
 interface ManualRecipientInteraction {
   addressTouched: boolean;
   amountTouched: boolean;
+}
+
+interface ConfigurationChoice {
+  value: string;
+  label: string;
+  helper: string;
+  badge?: string;
+  testId?: string;
+}
+
+interface UnavailableCapabilityNotice {
+  title: string;
+  description: string;
 }
 
 type InputMode = 'manual' | 'csv';
@@ -143,6 +167,72 @@ function SummaryPanel({
   );
 }
 
+function ConfigurationChoiceGroup({
+  title,
+  description,
+  selectedValue,
+  options,
+  onSelect,
+}: {
+  title: string;
+  description?: string;
+  selectedValue: string;
+  options: ConfigurationChoice[];
+  onSelect: (value: string) => void;
+}) {
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold text-slate-950">{title}</h3>
+      </div>
+      {description && <p className="mt-1 text-sm text-slate-500">{description}</p>}
+
+      <div className="mt-3 grid gap-3 sm:grid-cols-2">
+        {options.map((option) => {
+          const isSelected = option.value === selectedValue;
+
+          return (
+            <button
+              key={`${title}-${option.value}`}
+              type="button"
+              onClick={() => onSelect(option.value)}
+              data-testid={option.testId}
+              aria-pressed={isSelected}
+              className={`rounded-2xl border px-4 py-3 text-left transition-colors ${
+                isSelected
+                  ? 'border-[#1f69ff] bg-[#eef4ff] shadow-[0_18px_32px_-28px_rgba(31,105,255,0.95)]'
+                  : 'border-slate-200 bg-slate-50 hover:border-slate-300 hover:bg-white'
+              }`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span
+                  className={`text-sm font-semibold ${
+                    isSelected ? 'text-[#124ac4]' : 'text-slate-900'
+                  }`}
+                >
+                  {option.label}
+                </span>
+                {option.badge && (
+                  <span
+                    className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] ${
+                      isSelected
+                        ? 'bg-white text-[#124ac4]'
+                        : 'bg-slate-200 text-slate-600'
+                    }`}
+                  >
+                    {option.badge}
+                  </span>
+                )}
+              </div>
+              <p className="mt-2 text-xs leading-5 text-slate-500">{option.helper}</p>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 export default function App() {
   const account = useAccount();
   const walletChainId = useChainId();
@@ -170,6 +260,11 @@ export default function App() {
   const [gasEstimationError, setGasEstimationError] = React.useState<string | undefined>(undefined);
   const [transactionHash, setTransactionHash] = React.useState<string | undefined>(undefined);
   const [transactionError, setTransactionError] = React.useState<string | undefined>(undefined);
+  const [batchConfiguration, setBatchConfiguration] = React.useState<BatchConfiguration>(
+    DEFAULT_BATCH_CONFIGURATION,
+  );
+  const [unavailableCapabilityNotice, setUnavailableCapabilityNotice] =
+    React.useState<UnavailableCapabilityNotice | null>(null);
 
   const handleCSVUpload = (result: CSVUploadResult) => {
     setCsvData(result.recipients);
@@ -182,6 +277,46 @@ export default function App() {
     setCsvData([]);
     setCsvErrors([]);
     setCsvWarnings([]);
+  };
+
+  const openUnavailableCapabilityNotice = (title: string, description: string) => {
+    setUnavailableCapabilityNotice({ title, description });
+  };
+
+  const handleSenderWalletTypeSelect = (value: SenderWalletType) => {
+    if (value === 'MULTI_SIG') {
+      openUnavailableCapabilityNotice(
+        'Multi-sig is not available in v1 yet',
+        'The selector is now in place, but the v1 live flow still supports only the single-signer path. Single-signer remains selected for this batch.',
+      );
+      return;
+    }
+
+    setBatchConfiguration((current) => ({ ...current, senderWalletType: value }));
+  };
+
+  const handleExecutionMethodSelect = (value: ExecutionMethod) => {
+    if (value === 'THINBATCH') {
+      openUnavailableCapabilityNotice(
+        'ThinBatch is not available yet',
+        'ThinBatch is part of the planned execution surface, but the deployed builder and send path are not wired into the live app yet. Standard remains selected for now.',
+      );
+      return;
+    }
+
+    setBatchConfiguration((current) => ({ ...current, executionMethod: value }));
+  };
+
+  const handleErrorHandlingSelect = (value: ErrorHandlingPreference) => {
+    if (value === 'ATOMIC') {
+      openUnavailableCapabilityNotice(
+        'Atomic error handling is not wired yet',
+        'The control is now visible, but the live execution path still defaults to Partial while atomic batch handling is implemented end to end. Partial remains selected for this batch.',
+      );
+      return;
+    }
+
+    setBatchConfiguration((current) => ({ ...current, errorHandling: value }));
   };
 
   const addRecipient = () => {
@@ -321,6 +456,15 @@ export default function App() {
       : 0;
   const estimatedNetworkFee = gasEstimate?.estimatedFeeInFil || 0;
   const insufficientBalance = walletBalance < recipientTotal + feeTotal + estimatedNetworkFee;
+  const configurationSummary = React.useMemo(
+    () =>
+      [
+        getSenderWalletTypeLabel(batchConfiguration.senderWalletType),
+        getExecutionMethodLabel(batchConfiguration.executionMethod),
+        getErrorHandlingLabel(batchConfiguration.errorHandling),
+      ].join(' • '),
+    [batchConfiguration],
+  );
 
   const manualRowErrors = React.useMemo(
     () => collectManualRowIssues(manualDisplayErrors),
@@ -545,6 +689,31 @@ f1cj...,3.3`;
 
           <CustomConnectButton />
 
+          <div className="mt-6 rounded-[28px] border border-slate-200 bg-white px-4 py-4 shadow-[0_16px_40px_-32px_rgba(15,23,42,0.45)]">
+            <ConfigurationChoiceGroup
+              title="Wallet Type"
+              description="Choose the sender lane for this batch."
+              selectedValue={batchConfiguration.senderWalletType}
+              onSelect={(value) => handleSenderWalletTypeSelect(value as SenderWalletType)}
+              options={[
+                {
+                  value: 'SINGLE_SIG',
+                  label: 'Single-signer',
+                  helper: 'Default v1 sender flow.',
+                  badge: 'Default',
+                  testId: 'sender-wallet-single-sig',
+                },
+                {
+                  value: 'MULTI_SIG',
+                  label: 'Multi-sig',
+                  helper: 'Visible now, unlocks in a later phase.',
+                  badge: 'V2',
+                  testId: 'sender-wallet-multi-sig',
+                },
+              ]}
+            />
+          </div>
+
           <div className="mt-6 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 text-sm text-slate-500">
             Draft the batch first. Review and send are unlocked only after a wallet is connected on
             Filecoin Mainnet.
@@ -604,6 +773,78 @@ f1cj...,3.3`;
                 Download Template
               </button>
             </div>
+
+            <section className="mb-6 rounded-[28px] border border-slate-200 bg-white px-6 py-5 shadow-[0_20px_60px_-48px_rgba(15,23,42,0.45)] sm:px-8">
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                <div>
+                  <h2 className="text-lg font-semibold text-slate-950">Batch settings</h2>
+                  <p className="mt-1 max-w-2xl text-sm text-slate-500">
+                    Keep the batch configuration visible while composing recipients. Defaults are
+                    applied fresh on every load.
+                  </p>
+                </div>
+
+                <div className="flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                  <span className="rounded-full bg-slate-100 px-3 py-1">
+                    {getSenderWalletTypeLabel(batchConfiguration.senderWalletType)}
+                  </span>
+                  <span className="rounded-full bg-slate-100 px-3 py-1">
+                    {getExecutionMethodLabel(batchConfiguration.executionMethod)}
+                  </span>
+                  <span className="rounded-full bg-slate-100 px-3 py-1">
+                    {getErrorHandlingLabel(batchConfiguration.errorHandling)}
+                  </span>
+                </div>
+              </div>
+
+              <div className="mt-5 grid gap-5 xl:grid-cols-2">
+                <ConfigurationChoiceGroup
+                  title="Transaction method"
+                  description="Choose how SendFIL plans the batch execution."
+                  selectedValue={batchConfiguration.executionMethod}
+                  onSelect={(value) => handleExecutionMethodSelect(value as ExecutionMethod)}
+                  options={[
+                    {
+                      value: 'STANDARD',
+                      label: 'Standard',
+                      helper: 'Default path based on Multicall3 and FilForwarder.',
+                      badge: 'Default',
+                      testId: 'execution-method-standard',
+                    },
+                    {
+                      value: 'THINBATCH',
+                      label: 'ThinBatch',
+                      helper: 'Visible in the UI now, planned once the execution lane is ready.',
+                      badge: 'Planned',
+                      testId: 'execution-method-thinbatch',
+                    },
+                  ]}
+                />
+
+                <ConfigurationChoiceGroup
+                  title="Error handling"
+                  description="Set the intended batch failure behavior."
+                  selectedValue={batchConfiguration.errorHandling}
+                  onSelect={(value) => handleErrorHandlingSelect(value as ErrorHandlingPreference)}
+                  options={[
+                    {
+                      value: 'PARTIAL',
+                      label: 'Partial',
+                      helper: 'Default best-effort handling for the current flow.',
+                      badge: 'Default',
+                      testId: 'error-handling-partial',
+                    },
+                    {
+                      value: 'ATOMIC',
+                      label: 'Atomic',
+                      helper: 'Visible now, activates after the strict execution path is wired.',
+                      badge: 'Planned',
+                      testId: 'error-handling-atomic',
+                    },
+                  ]}
+                />
+              </div>
+            </section>
 
             {(activeValidationErrors.length > 0 || activeValidationWarnings.length > 0) && (
               <div className="mb-6 space-y-3">
@@ -838,6 +1079,9 @@ f1cj...,3.3`;
                         : `${draftRecipientCount} recipients • ${formatSummaryFil(recipientTotal)}`}
                     </p>
                     <p className="mt-1 text-sm text-slate-500">{reviewHint}</p>
+                    <p className="mt-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+                      {configurationSummary}
+                    </p>
                   </div>
 
                   <button
@@ -881,6 +1125,14 @@ f1cj...,3.3`;
         transactionState={transactionState}
         transactionHash={transactionHash}
         transactionError={transactionError}
+        batchConfiguration={batchConfiguration}
+      />
+
+      <UnavailableCapabilityModal
+        isOpen={unavailableCapabilityNotice !== null}
+        title={unavailableCapabilityNotice?.title ?? ''}
+        description={unavailableCapabilityNotice?.description ?? ''}
+        onClose={() => setUnavailableCapabilityNotice(null)}
       />
     </div>
   );

--- a/src/components/ReviewTransactionModal.tsx
+++ b/src/components/ReviewTransactionModal.tsx
@@ -4,6 +4,12 @@ import {
   getDuplicateRecipientWarnings,
   isDuplicateRecipientWarning,
 } from '../utils/recipientValidation';
+import {
+  getErrorHandlingLabel,
+  getExecutionMethodLabel,
+  getSenderWalletTypeLabel,
+  type BatchConfiguration,
+} from '../lib/batchConfiguration';
 
 export type TransactionState = 'review' | 'signing' | 'pending' | 'confirmed' | 'failed';
 
@@ -41,6 +47,7 @@ export interface ReviewTransactionModalProps {
   transactionState: TransactionState;
   transactionHash?: string;
   transactionError?: string;
+  batchConfiguration: BatchConfiguration;
 }
 
 // Format FIL amounts for display
@@ -80,6 +87,7 @@ export const ReviewTransactionModal: React.FC<ReviewTransactionModalProps> = ({
   transactionState,
   transactionHash,
   transactionError,
+  batchConfiguration,
 }) => {
   const [showDetails, setShowDetails] = useState(false);
   const [showGasDetails, setShowGasDetails] = useState(false);
@@ -234,6 +242,38 @@ export const ReviewTransactionModal: React.FC<ReviewTransactionModalProps> = ({
 
       {/* Summary Section */}
       <div className="space-y-3 mb-4">
+        <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+            Batch configuration
+          </p>
+          <div className="mt-3 grid gap-3 sm:grid-cols-3">
+            <div>
+              <p className="text-xs font-medium uppercase tracking-[0.16em] text-slate-400">
+                Wallet type
+              </p>
+              <p className="mt-1 text-sm font-semibold text-slate-900">
+                {getSenderWalletTypeLabel(batchConfiguration.senderWalletType)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-medium uppercase tracking-[0.16em] text-slate-400">
+                Method
+              </p>
+              <p className="mt-1 text-sm font-semibold text-slate-900">
+                {getExecutionMethodLabel(batchConfiguration.executionMethod)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-medium uppercase tracking-[0.16em] text-slate-400">
+                Error handling
+              </p>
+              <p className="mt-1 text-sm font-semibold text-slate-900">
+                {getErrorHandlingLabel(batchConfiguration.errorHandling)}
+              </p>
+            </div>
+          </div>
+        </div>
+
         <div className="flex justify-between items-center">
           <span className="text-gray-600">Total to send:</span>
           <span className="font-semibold text-lg">{formatFil(recipientTotal)}</span>

--- a/src/components/UnavailableCapabilityModal.tsx
+++ b/src/components/UnavailableCapabilityModal.tsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useRef } from 'react';
+
+export interface UnavailableCapabilityModalProps {
+  isOpen: boolean;
+  title: string;
+  description: string;
+  onClose: () => void;
+}
+
+const UnavailableCapabilityModal: React.FC<UnavailableCapabilityModalProps> = ({
+  isOpen,
+  title,
+  description,
+  onClose,
+}) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (isOpen && modalRef.current) {
+      modalRef.current.focus();
+    }
+  }, [isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-slate-950/55 px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="unavailable-capability-title"
+      onClick={onClose}
+    >
+      <div
+        ref={modalRef}
+        tabIndex={-1}
+        className="w-full max-w-md rounded-[28px] bg-white p-6 shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+        data-testid="unavailable-capability-modal"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-400">
+              SendFIL
+            </p>
+            <h2
+              id="unavailable-capability-title"
+              className="mt-2 text-xl font-semibold text-slate-950"
+            >
+              {title}
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex h-10 w-10 items-center justify-center rounded-xl bg-slate-100 text-2xl leading-none text-slate-500 transition-colors hover:bg-slate-200 hover:text-slate-900"
+            aria-label="Close capability notice"
+          >
+            x
+          </button>
+        </div>
+
+        <p className="mt-4 text-sm leading-6 text-slate-600">{description}</p>
+
+        <div className="mt-6 flex justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-xl bg-[#1f69ff] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#1857d4]"
+          >
+            Keep default
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UnavailableCapabilityModal;

--- a/src/components/__tests__/ReviewTransactionModal.test.tsx
+++ b/src/components/__tests__/ReviewTransactionModal.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import ReviewTransactionModal, {
   type ReviewTransactionModalProps,
 } from '../ReviewTransactionModal';
+import { DEFAULT_BATCH_CONFIGURATION } from '../../lib/batchConfiguration';
 
 vi.mock('wagmi', () => ({
   useChainId: () => 314,
@@ -33,6 +34,7 @@ function getBaseProps(): ReviewTransactionModalProps {
     transactionState: 'review',
     transactionHash: undefined,
     transactionError: undefined,
+    batchConfiguration: DEFAULT_BATCH_CONFIGURATION,
   };
 }
 
@@ -130,6 +132,19 @@ describe('ReviewTransactionModal', () => {
 
     expect(checkbox).toBeNull();
     expect(sendButton.disabled).toBe(false);
+  });
+
+  it('renders the batch configuration summary', () => {
+    const props = getBaseProps();
+
+    act(() => {
+      root.render(<ReviewTransactionModal {...props} />);
+    });
+
+    expect(container.textContent).toContain('Batch configuration');
+    expect(container.textContent).toContain('Single-signer');
+    expect(container.textContent).toContain('Standard');
+    expect(container.textContent).toContain('Partial');
   });
 
   it('resets duplicate acknowledgment when the modal reopens', () => {

--- a/src/lib/batchConfiguration.ts
+++ b/src/lib/batchConfiguration.ts
@@ -1,0 +1,27 @@
+export type SenderWalletType = 'SINGLE_SIG' | 'MULTI_SIG';
+export type ExecutionMethod = 'STANDARD' | 'THINBATCH';
+export type ErrorHandlingPreference = 'PARTIAL' | 'ATOMIC';
+
+export interface BatchConfiguration {
+  senderWalletType: SenderWalletType;
+  executionMethod: ExecutionMethod;
+  errorHandling: ErrorHandlingPreference;
+}
+
+export const DEFAULT_BATCH_CONFIGURATION: BatchConfiguration = {
+  senderWalletType: 'SINGLE_SIG',
+  executionMethod: 'STANDARD',
+  errorHandling: 'PARTIAL',
+};
+
+export function getSenderWalletTypeLabel(value: SenderWalletType): string {
+  return value === 'SINGLE_SIG' ? 'Single-signer' : 'Multi-sig';
+}
+
+export function getExecutionMethodLabel(value: ExecutionMethod): string {
+  return value === 'STANDARD' ? 'Standard' : 'ThinBatch';
+}
+
+export function getErrorHandlingLabel(value: ErrorHandlingPreference): string {
+  return value === 'PARTIAL' ? 'Partial' : 'Atomic';
+}


### PR DESCRIPTION
## Summary

Add visible batch-configuration controls to the SendFIL UI without implying unimplemented execution capabilities are already live.

## What changed

- added a wallet-type selector in the left rail with `Single-signer` as the default active v1 lane
- added visible `Transaction method` and `Error handling` toggle groups above the recipient workflow
- added a reusable unavailable-capability modal so clicking unsupported options keeps the UI visible while preserving the current defaults
- added shared batch-configuration types and labels
- surfaced the active batch configuration in the review modal and sticky footer summary
- updated the review modal test coverage for the configuration summary

## Why

The DevSpec calls for sender-visible batch configuration. This PR puts the UI structure in place now while keeping unsupported paths honest:

- `Multi-sig` remains unavailable in v1 and shows a notice
- `ThinBatch` remains visible but unavailable until the execution lane is wired
- `Atomic` remains visible but unavailable until the strict execution path is implemented
- defaults reset on refresh; nothing is persisted in local storage

## Validation

- `yarn test`
- `yarn lint`
- `yarn typecheck`

## Follow-up

Subsequent PRs can wire these controls into the underlying execution and estimation paths as those capabilities land.