### PR TITLE
[codex] Restore Phase 0 TypeScript baseline

### DIFF
--- a/src/lib/DataProvider/rpc.ts
+++ b/src/lib/DataProvider/rpc.ts
@@ -4,6 +4,38 @@ import { JsonRpcSuccess, JsonRpcError, RpcSuccess } from './types';
 
 let requestId = 1;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getRetryAttemptNumber(context: unknown): number | undefined {
+  if (!isRecord(context) || typeof context.attemptNumber !== 'number') {
+    return undefined;
+  }
+
+  return context.attemptNumber;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (isRecord(error) && typeof error.message === 'string') {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+function getRetryErrorMessage(context: unknown): string {
+  if (isRecord(context) && 'error' in context) {
+    return getErrorMessage(context.error);
+  }
+
+  return getErrorMessage(context);
+}
+
 function getRpcConfig() {
   const primary = import.meta.env.VITE_GLIF_RPC_URL_PRIMARY as string | undefined;
   const fallback =
@@ -49,9 +81,9 @@ export async function callRpc<T = unknown>(
     },
     {
       retries: 1, // only one fail-over attempt
-      onFailedAttempt: (err) => {
+      onFailedAttempt: (context: unknown) => {
         console.warn(
-          `[DataProvider] RPC attempt ${err.attemptNumber} failed: ${err.message}`,
+          `[DataProvider] RPC attempt ${getRetryAttemptNumber(context) ?? 'unknown'} failed: ${getRetryErrorMessage(context)}`,
         );
       },
     },


### PR DESCRIPTION
## What changed
- updated `src/lib/DataProvider/rpc.ts` to stop assuming `p-retry` exposes `message` directly on the `onFailedAttempt` callback argument
- added small local helpers to safely read the retry attempt number and normalize the underlying error message for logging

## Why this changed
`sendfil` declares `p-retry@^7.1.1`, where `onFailedAttempt` receives a retry context object and the thrown error lives on `context.error`. The existing code treated the callback argument like the older decorated `Error` shape and accessed `err.message` directly, which breaks `tsc -b` against the declared typings.

## Impact
- restores the Phase 0 TypeScript baseline without changing the RPC retry behavior
- keeps retry logging behavior intact while making the callback access type-safe across the expected context shape

## Root cause
The typecheck failure came from a dependency API mismatch: the source still used the pre-v7 `p-retry` callback shape, but the repo lockfile targets the v7 context-based API.

## Validation
- `yarn typecheck`
- `yarn lint`
- `yarn test --run`
