### PR TITLE
[codex] Fix manual entry mobile remove button layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -933,8 +933,8 @@ f1cj...,3.3`;
 
                       return (
                         <div key={rowNumber}>
-                          <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_180px_48px]">
-                            <div>
+                          <div className="grid grid-cols-[minmax(0,1fr)_48px] gap-3 md:grid-cols-[minmax(0,1fr)_180px_48px]">
+                            <div className="col-span-2 md:col-span-1">
                               <label className="mb-1 block text-xs font-medium text-slate-500 md:hidden">
                                 Receiver
                               </label>
@@ -976,7 +976,7 @@ f1cj...,3.3`;
                               />
                             </div>
 
-                            <div className="flex items-center justify-end md:justify-center">
+                            <div className="flex items-end justify-end md:justify-center">
                               {manualRecipients.length > 1 ? (
                                 <button
                                   type="button"


### PR DESCRIPTION
## What changed
- keep the manual recipient receiver field full width on narrow screens
- place the `FIL Amount` input and remove `×` button on the same row in mobile widths
- bottom-align the remove button with the amount input so the control stays visually anchored

## Why
In the manual entry view, the remove button drifted below the amount field when the window narrowed. This keeps the action adjacent to the amount input and avoids the awkward mobile layout.

## Impact
- cleaner mobile and narrow-window manual entry layout
- no behavior change to validation or submission flow

## Validation
- `./node_modules/.bin/eslint src/App.tsx`
- `./node_modules/.bin/tsc -b`