### PR TITLE
Fix button styles: remove global CSS override of Tailwind

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -200,18 +200,23 @@ function SummaryPanel({
   );
 }
 
+const choiceCardSelectedShadow =
+  'shadow-[0_18px_36px_-26px_rgba(31,105,255,0.82),0_14px_32px_-28px_rgba(60,212,160,0.22)]';
+
 function ConfigurationChoiceGroup({
   title,
   description,
   selectedValue,
   options,
   onSelect,
+  variant = 'cards',
 }: {
   title: string;
   description?: string;
   selectedValue: string;
   options: ConfigurationChoice[];
   onSelect: (value: string) => void;
+  variant?: 'cards' | 'segmented';
 }) {
   return (
     <div>
@@ -220,50 +225,75 @@ function ConfigurationChoiceGroup({
       </div>
       {description && <p className="mt-1 text-sm text-slate-500">{description}</p>}
 
-      <div className="mt-3 grid gap-3 sm:grid-cols-2">
-        {options.map((option) => {
-          const isSelected = option.value === selectedValue;
+      {variant === 'segmented' ? (
+        <div className="mt-3 flex gap-2">
+          {options.map((option) => {
+            const isSelected = option.value === selectedValue;
 
-          return (
-            <button
-              key={`${title}-${option.value}`}
-              type="button"
-              onClick={() => onSelect(option.value)}
-              data-testid={option.testId}
-              aria-pressed={isSelected}
-              className={`rounded-2xl border px-4 py-3 text-left transition-colors ${
-                isSelected
-                  ? 'border-[#1f69ff] bg-[#eef4ff] shadow-[0_18px_32px_-28px_rgba(31,105,255,0.95)]'
-                  : 'border-slate-200 bg-slate-50 hover:border-slate-300 hover:bg-white'
-              }`}
-            >
-              <div className="flex items-center justify-between gap-2">
-                <span
-                  className={`text-sm font-semibold ${
-                    isSelected ? 'text-[#124ac4]' : 'text-slate-900'
-                  }`}
-                >
-                  <span className="whitespace-nowrap">{option.label}</span>
-                </span>
-                {option.badge && (
+            return (
+              <button
+                key={`${title}-${option.value}`}
+                type="button"
+                onClick={() => onSelect(option.value)}
+                data-testid={option.testId}
+                aria-pressed={isSelected}
+                className={`min-h-[44px] flex-1 rounded-2xl border px-3 py-2.5 text-center text-sm font-semibold transition-colors ${
+                  isSelected
+                    ? `border-[#1f69ff] bg-white text-[#124ac4] ${choiceCardSelectedShadow}`
+                    : 'border-slate-200 bg-white text-slate-800 hover:border-slate-300 hover:bg-slate-50'
+                }`}
+              >
+                <span className="whitespace-nowrap">{option.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="mt-3 grid gap-3 sm:grid-cols-2">
+          {options.map((option) => {
+            const isSelected = option.value === selectedValue;
+
+            return (
+              <button
+                key={`${title}-${option.value}`}
+                type="button"
+                onClick={() => onSelect(option.value)}
+                data-testid={option.testId}
+                aria-pressed={isSelected}
+                className={`rounded-2xl border px-4 py-3 text-left transition-colors ${
+                  isSelected
+                    ? `border-[#1f69ff] bg-[#eef4ff] ${choiceCardSelectedShadow}`
+                    : 'border-slate-200 bg-slate-50 hover:border-slate-300 hover:bg-white'
+                }`}
+              >
+                <div className="flex items-center justify-between gap-2">
                   <span
-                    className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] ${
-                      isSelected
-                        ? 'bg-white text-[#124ac4]'
-                        : 'bg-slate-200 text-slate-600'
+                    className={`text-sm font-semibold ${
+                      isSelected ? 'text-[#124ac4]' : 'text-slate-900'
                     }`}
                   >
-                    {option.badge}
+                    <span className="whitespace-nowrap">{option.label}</span>
                   </span>
+                  {option.badge && (
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] ${
+                        isSelected
+                          ? 'bg-white text-[#124ac4]'
+                          : 'bg-slate-200 text-slate-600'
+                      }`}
+                    >
+                      {option.badge}
+                    </span>
+                  )}
+                </div>
+                {option.helper && (
+                  <p className="mt-2 text-xs leading-5 text-slate-500">{option.helper}</p>
                 )}
-              </div>
-              {option.helper && (
-                <p className="mt-2 text-xs leading-5 text-slate-500">{option.helper}</p>
-              )}
-            </button>
-          );
-        })}
-      </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }
@@ -781,6 +811,7 @@ f1cj...,3.3`;
           <div className="mt-6 rounded-[28px] border border-slate-200 bg-white px-4 py-4 shadow-[0_16px_40px_-32px_rgba(15,23,42,0.45)]">
             <ConfigurationChoiceGroup
               title="Wallet Type"
+              variant="segmented"
               selectedValue={batchConfiguration.senderWalletType}
               onSelect={(value) => handleSenderWalletTypeSelect(value as SenderWalletType)}
               options={[
@@ -838,15 +869,15 @@ f1cj...,3.3`;
             <NetworkBanner />
 
             <div className="mb-6 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-              <div className="inline-flex rounded-2xl border border-slate-200 bg-white p-1 shadow-sm">
+              <div className="inline-flex rounded-full border border-slate-200 bg-white p-1 shadow-sm">
                 <button
                   type="button"
                   onClick={() => setInputMode('manual')}
                   data-testid="manual-mode-toggle"
-                  className={`rounded-xl px-4 py-2 text-sm font-medium transition-colors ${
+                  className={`rounded-full px-5 py-2.5 text-sm font-semibold transition-colors ${
                     inputMode === 'manual'
-                      ? 'bg-[#1f69ff] text-white shadow-sm'
-                      : 'text-slate-500 hover:text-slate-900'
+                      ? `bg-[#1f69ff] text-white ${choiceCardSelectedShadow}`
+                      : 'text-slate-600 hover:bg-slate-50 hover:text-slate-900'
                   }`}
                 >
                   Manual Entry
@@ -854,10 +885,10 @@ f1cj...,3.3`;
                 <button
                   type="button"
                   onClick={() => setInputMode('csv')}
-                  className={`rounded-xl px-4 py-2 text-sm font-medium transition-colors ${
+                  className={`rounded-full px-5 py-2.5 text-sm font-semibold transition-colors ${
                     inputMode === 'csv'
-                      ? 'bg-[#1f69ff] text-white shadow-sm'
-                      : 'text-slate-500 hover:text-slate-900'
+                      ? `bg-[#1f69ff] text-white ${choiceCardSelectedShadow}`
+                      : 'text-slate-600 hover:bg-slate-50 hover:text-slate-900'
                   }`}
                 >
                   CSV Upload
@@ -867,7 +898,7 @@ f1cj...,3.3`;
               <button
                 type="button"
                 onClick={handleDownloadTemplate}
-                className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50"
+                className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-5 py-2.5 text-sm font-semibold text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50"
               >
                 Download Template
               </button>
@@ -1132,7 +1163,7 @@ f1cj...,3.3`;
                   <button
                     type="button"
                     onClick={addRecipient}
-                    className="mt-6 inline-flex items-center rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-[#1f69ff] transition-colors hover:border-slate-300 hover:bg-slate-100"
+                    className="mt-6 inline-flex items-center rounded-full border border-[#1f69ff]/35 bg-white px-5 py-2.5 text-sm font-semibold text-[#124ac4] transition-colors hover:border-[#1f69ff] hover:bg-[#f5f8ff]"
                   >
                     + Add recipient
                   </button>
@@ -1232,10 +1263,10 @@ f1cj...,3.3`;
                     onClick={handleReview}
                     disabled={reviewDisabled}
                     data-testid="review-batch-button"
-                    className={`min-w-[220px] rounded-xl px-5 py-3 text-sm font-medium transition-colors ${
+                    className={`min-w-[220px] rounded-full px-6 py-3 text-sm font-semibold transition-colors ${
                       reviewDisabled
                         ? 'cursor-not-allowed bg-slate-200 text-slate-500'
-                        : 'bg-[#1f69ff] text-white hover:bg-[#1857d4]'
+                        : `bg-[#1f69ff] text-white hover:bg-[#1857d4] ${choiceCardSelectedShadow}`
                     }`}
                   >
                     {!isConnected

--- a/src/components/CustomConnectButton.tsx
+++ b/src/components/CustomConnectButton.tsx
@@ -12,6 +12,9 @@ import {
 
 const E2E_MOCK_WALLET_ENABLED = import.meta.env.VITE_E2E_MOCK_WALLET === 'true';
 
+const primaryActionShadow =
+  'shadow-[0_18px_36px_-26px_rgba(31,105,255,0.82),0_14px_32px_-28px_rgba(60,212,160,0.22)]';
+
 export const CustomConnectButton: React.FC = () => {
   const [showAccountModal, setShowAccountModal] = useState(false);
   const { disconnect } = useDisconnect();
@@ -34,7 +37,7 @@ export const CustomConnectButton: React.FC = () => {
           {mockNetwork?.walletLabel ?? 'Filecoin Mainnet'}
         </div>
         <div
-          className="rounded-[22px] bg-[#4a84ea] px-4 py-4 text-left font-mono text-sm text-white shadow-[0_22px_35px_-28px_rgba(74,132,234,0.95)]"
+          className={`rounded-full bg-[#4a84ea] px-4 py-4 text-left font-mono text-sm text-white ${primaryActionShadow}`}
           data-testid="mock-wallet-chip"
         >
           <div className="text-base font-semibold">Test Wallet</div>
@@ -71,7 +74,7 @@ export const CustomConnectButton: React.FC = () => {
           <button
             type="button"
             onClick={openConnectModal}
-            className="w-full rounded-2xl bg-[#1f69ff] px-4 py-3 text-sm font-medium text-white shadow-[0_22px_35px_-28px_rgba(31,105,255,0.95)] transition-colors hover:bg-[#1857d4]"
+            className={`w-full rounded-full bg-[#1f69ff] px-5 py-3 text-sm font-semibold text-white transition-colors hover:bg-[#1857d4] ${primaryActionShadow}`}
           >
             Connect Wallet
           </button>
@@ -90,7 +93,7 @@ export const CustomConnectButton: React.FC = () => {
               <button
                 type="button"
                 onClick={openChainModal}
-                className={`w-full rounded-2xl border px-4 py-3 text-left text-sm font-medium transition-colors ${
+                className={`w-full rounded-full border px-4 py-3 text-left text-sm font-semibold transition-colors ${
                   isWrongNetwork
                     ? 'border-red-200 bg-red-50 text-red-800 hover:bg-red-100'
                     : 'border-slate-900 bg-slate-900 text-white hover:bg-slate-800'
@@ -114,7 +117,7 @@ export const CustomConnectButton: React.FC = () => {
               <button
                 type="button"
                 onClick={() => setShowAccountModal(true)}
-                className="w-full rounded-[22px] bg-[#4a84ea] px-4 py-4 text-left text-white shadow-[0_22px_35px_-28px_rgba(74,132,234,0.95)] transition-colors hover:bg-[#3f77dd]"
+                className={`w-full rounded-full bg-[#4a84ea] px-4 py-4 text-left text-white transition-colors hover:bg-[#3f77dd] ${primaryActionShadow}`}
                 title={delegatedAddress}
               >
                 <div className="font-mono text-base font-semibold">{displayAddress}</div>

--- a/src/index.css
+++ b/src/index.css
@@ -34,26 +34,22 @@ h1 {
   line-height: 1.1;
 }
 
+/* Do not reset padding, border-radius, or border here — unlayered rules win over
+   Tailwind @layer utilities and would flatten real buttons (choice cards, pills). */
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0;
-  font-size: 1em;
-  font-weight: inherit;
   font-family: inherit;
-  background-color: transparent;
+  font-size: inherit;
+  font-weight: inherit;
   cursor: pointer;
-  transition:
-    border-color 0.2s ease,
-    background-color 0.2s ease,
-    color 0.2s ease;
 }
-button:hover {
-  border-color: transparent;
-}
-button:focus,
-button:focus-visible {
+
+button:focus {
   outline: none;
+}
+
+button:focus-visible {
+  outline: 2px solid #1f69ff;
+  outline-offset: 2px;
 }
 
 /* Hide the original 'Ethereum' text and replace with 'Filecoin' */


### PR DESCRIPTION
Global unlayered button rules in index.css were overriding padding, border-radius, and borders from Tailwind utilities, flattening choice cards and pills. Replace with minimal inherited font/cursor rules.

Restore segmented wallet toggle, pill controls, blue-teal shadows on primary actions, and align CustomConnectButton with the same system.

## What changed?


## Invariants touched

Reference `docs/invariants.md` IDs where applicable.

## Execution boundaries touched

- [ ] UI
- [ ] validation
- [ ] amount parsing
- [ ] duplicate detection
- [ ] review/send gating
- [ ] network/wallet gating
- [ ] RPC
- [ ] transaction builder
- [ ] fee/value accounting
- [ ] tests only
- [ ] docs only

## CI / verification

- [ ] `yarn lint`
- [ ] `yarn typecheck`
- [ ] `yarn test:unit`
- [ ] `yarn build`
- [ ] `yarn test:e2e:smoke` if review/send UI changed
- [ ] `yarn test:future` if implementing or modifying future invariant tests

## Red-zone review

Required if touching transaction builder, wallet signing/submission,
`msg.value` or value accounting, amount parsing, network gating, RPC
`getCode`/`eth_getCode`, or fee rows.

- [ ] value accounting reviewed
- [ ] no JS Number precision regression in money-moving path
- [ ] wrong-network behavior reviewed
- [ ] estimate/send config alignment reviewed
- [ ] no live RPC/wallet dependency added to tests

## Known gaps

