### PR TITLE
Add submit-time balance recheck

### DIFF
--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -26,6 +26,7 @@ Use this catalog before changing validation, network gating, review/send flow, R
 | `INV-BATCH-001` | Enforce the 500-recipient cap | `implemented` | validation | `src/utils/__tests__/recipientValidation.test.ts` |
 | `INV-DUP-001` | Duplicate recipients require explicit confirmation before Send | `implemented` | duplicate detection, review UI gating | `src/utils/__tests__/recipientValidation.test.ts`, `src/components/__tests__/ReviewTransactionModal.test.tsx`, `tests/e2e/review-flow.spec.ts` |
 | `INV-NET-001` | Wrong network disables Send | `implemented` | network/wallet gating, review UI gating | `src/__tests__/app.invariants.test.tsx` |
+| `INV-BAL-001` | Submit-time balance recheck blocks EVM sends when current balance is insufficient | `implemented` | submit guard, wallet RPC | `src/lib/transaction/__tests__/submitBalanceCheck.test.ts`, `src/lib/transaction/__tests__/useExecuteBatch.submitBalance.test.tsx` |
 | `INV-RPC-001` | Contract recipients detected via `eth_getCode` are blocked | `not implemented` | RPC contract-recipient check, review UI gating | `src/__tests__/contractRecipientGuard.future.test.tsx` |
 | `INV-EXEC-001` | Review estimate and submission use the same execution config | `implemented` | estimate/execute flow, transaction builder | `src/lib/transaction/__tests__/batchExecution.test.ts`, `src/__tests__/app.invariants.test.tsx` |
 
@@ -249,6 +250,35 @@ network/wallet gating, review UI gating
 `implemented`
 
 Current repo note: the live block happens at the App review boundary, not by a wallet-driven switch action inside the review modal.
+
+## INV-BAL-001 — Submit-Time Balance Recheck
+
+### Rule
+The existing EVM/wagmi submit path must re-read the connected sender balance immediately before wallet submission. The batch must not be submitted unless current balance covers the prepared batch transfer value plus the latest estimated network fee.
+
+### Why this matters
+The review-time balance can become stale if the sender spends or receives FIL while the review modal is open. Sending without a fresh check can push an avoidable insufficient-funds request into the wallet.
+
+### Execution boundary
+submit guard, wallet RPC
+
+### Acceptance criteria
+- The recheck runs after submit-time gas estimation and before `sendTransactionAsync`.
+- Required balance includes prepared transfer value, which contains recipient rows and appended fee rows, plus estimated network fee.
+- If current balance is insufficient, wallet submission is not called.
+- Unsupported network state cannot bypass the submit guard.
+- Native Filecoin senders have an explicit unsupported/not-implemented helper path until native sender execution exists.
+
+### Tests
+- `src/lib/transaction/__tests__/submitBalanceCheck.test.ts`
+  - `describe('submit-time balance recheck helper', ...)`
+- `src/lib/transaction/__tests__/useExecuteBatch.submitBalance.test.tsx`
+  - `describe('useExecuteBatch submit-time balance recheck', ...)`
+
+### Status
+`implemented`
+
+Current repo note: this is implemented for the live EVM/wagmi sender path only. The helper is sender-aware, but native Filecoin sender submission is still not wired into the live app.
 
 ## INV-RPC-001 — Contract recipients detected via `eth_getCode` are blocked
 

--- a/src/lib/transaction/__tests__/submitBalanceCheck.test.ts
+++ b/src/lib/transaction/__tests__/submitBalanceCheck.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getAddress } from 'viem';
+import { getNetworkConfig } from '../../networks';
+import {
+  createSubmitBalanceCheckError,
+  recheckSubmitBalance,
+  type SubmitBalanceSender,
+} from '../submitBalanceCheck';
+
+const EVM_SENDER = {
+  kind: 'evm',
+  address: getAddress('0x9999999999999999999999999999999999999999'),
+  chainId: 314,
+} satisfies SubmitBalanceSender;
+
+describe('submit-time balance recheck helper', () => {
+  it('allows EVM submission when balance covers transfers and estimated network fee', async () => {
+    const network = getNetworkConfig('mainnet');
+    const readEvmBalance = vi.fn().mockResolvedValue(111n);
+
+    const result = await recheckSubmitBalance({
+      sender: EVM_SENDER,
+      network,
+      transferTotalAttoFil: 101n,
+      estimatedNetworkFeeAttoFil: 10n,
+      readEvmBalance,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      transferTotalAttoFil: 101n,
+      estimatedNetworkFeeAttoFil: 10n,
+      requiredAttoFil: 111n,
+      availableAttoFil: 111n,
+    });
+    expect(readEvmBalance).toHaveBeenCalledWith({
+      address: EVM_SENDER.address,
+      chainId: 314,
+    });
+  });
+
+  it('blocks EVM submission when balance no longer covers transfers and estimated network fee', async () => {
+    const result = await recheckSubmitBalance({
+      sender: EVM_SENDER,
+      network: getNetworkConfig('mainnet'),
+      transferTotalAttoFil: 101n,
+      estimatedNetworkFeeAttoFil: 10n,
+      readEvmBalance: vi.fn().mockResolvedValue(110n),
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'INSUFFICIENT_BALANCE',
+      requiredAttoFil: 111n,
+      availableAttoFil: 110n,
+    });
+
+    if (!result.ok) {
+      expect(createSubmitBalanceCheckError(result, 'PARTIAL').message).toBe(
+        'Balance changed. Please review again.',
+      );
+    }
+  });
+
+  it('treats unsupported networks as blocking before balance reads', async () => {
+    const readEvmBalance = vi.fn().mockResolvedValue(111n);
+
+    const result = await recheckSubmitBalance({
+      sender: EVM_SENDER,
+      network: undefined,
+      transferTotalAttoFil: 101n,
+      estimatedNetworkFeeAttoFil: 10n,
+      readEvmBalance,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'UNSUPPORTED_NETWORK',
+    });
+    expect(readEvmBalance).not.toHaveBeenCalled();
+  });
+
+  it('returns an explicit not-implemented path for native Filecoin senders', async () => {
+    const result = await recheckSubmitBalance({
+      sender: {
+        kind: 'native',
+        address: 'f1sender',
+        networkKey: 'mainnet',
+      },
+      network: getNetworkConfig('mainnet'),
+      transferTotalAttoFil: 101n,
+      estimatedNetworkFeeAttoFil: 10n,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'UNSUPPORTED_SENDER',
+    });
+  });
+});

--- a/src/lib/transaction/__tests__/useExecuteBatch.submitBalance.test.tsx
+++ b/src/lib/transaction/__tests__/useExecuteBatch.submitBalance.test.tsx
@@ -1,0 +1,208 @@
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { createRoot, type Root } from 'react-dom/client';
+import { getAddress } from 'viem';
+import { getNetworkConfig } from '../../networks';
+import { BatchExecutionError } from '../errorHandling';
+import {
+  prepareBatchExecution,
+  type BatchExecutionRecipient,
+} from '../batchExecution';
+import {
+  useExecuteBatch,
+  type UseExecuteBatchReturn,
+} from '../useExecuteBatch';
+
+const ACCOUNT = getAddress('0x9999999999999999999999999999999999999999');
+const RECIPIENT = getAddress('0x1234567890abcdef1234567890abcdef12345678');
+const FEE_A = getAddress('0x1111111111111111111111111111111111111111');
+const FEE_B = getAddress('0x2222222222222222222222222222222222222222');
+const HASH = `0x${'a'.repeat(64)}` as `0x${string}`;
+
+const recipientsWithFees: BatchExecutionRecipient[] = [
+  { address: RECIPIENT, amount: 1 },
+  { address: FEE_A, amount: 0.005 },
+  { address: FEE_B, amount: 0.005 },
+];
+
+const estimateGasMock = vi.fn();
+const getGasPriceMock = vi.fn();
+const getBalanceMock = vi.fn();
+const sendTransactionAsyncMock = vi.fn();
+let mockChainId = 314;
+
+vi.mock('wagmi', () => ({
+  useAccount: () => ({
+    address: ACCOUNT as `0x${string}`,
+    isConnected: true,
+  }),
+  useChainId: () => mockChainId,
+  usePublicClient: () => ({
+    estimateGas: estimateGasMock,
+    getGasPrice: getGasPriceMock,
+    getBalance: getBalanceMock,
+  }),
+  useSendTransaction: () => ({
+    sendTransactionAsync: sendTransactionAsyncMock,
+  }),
+  useWaitForTransactionReceipt: () => ({
+    isLoading: false,
+    isSuccess: false,
+    isError: false,
+    error: undefined,
+  }),
+}));
+
+function HookHarness({ onValue }: { onValue: (value: UseExecuteBatchReturn) => void }) {
+  onValue(useExecuteBatch());
+  return null;
+}
+
+async function flushAsyncWork() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe('useExecuteBatch submit-time balance recheck', () => {
+  let dom: JSDOM;
+  let container: HTMLDivElement;
+  let root: Root;
+  let latestHook: UseExecuteBatchReturn | undefined;
+
+  beforeEach(async () => {
+    mockChainId = 314;
+    latestHook = undefined;
+    estimateGasMock.mockReset();
+    getGasPriceMock.mockReset();
+    getBalanceMock.mockReset();
+    sendTransactionAsyncMock.mockReset();
+
+    estimateGasMock.mockResolvedValue(1_000n);
+    getGasPriceMock.mockResolvedValue(10n);
+    sendTransactionAsyncMock.mockResolvedValue(HASH);
+
+    dom = new JSDOM('<!doctype html><html><body></body></html>', {
+      url: 'http://localhost',
+    });
+
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('navigator', dom.window.navigator);
+    vi.stubGlobal('Node', dom.window.Node);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('CustomEvent', dom.window.CustomEvent);
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root.render(<HookHarness onValue={(value) => { latestHook = value; }} />);
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    dom.window.close();
+  });
+
+  function getPreparedBatch() {
+    return prepareBatchExecution(
+      recipientsWithFees,
+      'PARTIAL',
+      getNetworkConfig('mainnet'),
+    );
+  }
+
+  async function executeAndCaptureError() {
+    let capturedError: unknown;
+
+    await act(async () => {
+      try {
+        await latestHook?.executeBatch(recipientsWithFees, 'PARTIAL');
+      } catch (error) {
+        capturedError = error;
+      }
+    });
+
+    await flushAsyncWork();
+    return capturedError;
+  }
+
+  it('blocks submit when balance becomes insufficient after review', async () => {
+    const prepared = getPreparedBatch();
+    const submitNetworkFee = 1_100n * 10n;
+    getBalanceMock.mockResolvedValue(prepared.totalValueAttoFil + submitNetworkFee - 1n);
+
+    const capturedError = await executeAndCaptureError();
+
+    expect(capturedError).toBeInstanceOf(BatchExecutionError);
+    expect((capturedError as BatchExecutionError).message).toBe(
+      'Balance changed. Please review again.',
+    );
+    expect(sendTransactionAsyncMock).not.toHaveBeenCalled();
+    expect(latestHook?.state).toBe('failed');
+    expect(latestHook?.error?.category).toBe('INSUFFICIENT_FUNDS');
+  });
+
+  it('allows submit when balance still covers transfers, fees, and network fee', async () => {
+    const prepared = getPreparedBatch();
+    const submitNetworkFee = 1_100n * 10n;
+    getBalanceMock.mockResolvedValue(prepared.totalValueAttoFil + submitNetworkFee);
+
+    await act(async () => {
+      await expect(latestHook?.executeBatch(recipientsWithFees, 'PARTIAL')).resolves.toBe(HASH);
+    });
+
+    expect(getBalanceMock).toHaveBeenCalledWith({ address: ACCOUNT });
+    expect(sendTransactionAsyncMock).toHaveBeenCalledTimes(1);
+    expect(sendTransactionAsyncMock).toHaveBeenCalledWith({
+      to: prepared.batch.to,
+      data: prepared.batch.data,
+      value: prepared.batch.value,
+    });
+  });
+
+  it('does not let an unsupported network bypass submit gating', async () => {
+    mockChainId = 1;
+
+    await act(async () => {
+      root.render(<HookHarness onValue={(value) => { latestHook = value; }} />);
+    });
+
+    const capturedError = await executeAndCaptureError();
+
+    expect(capturedError).toBeInstanceOf(BatchExecutionError);
+    expect(estimateGasMock).not.toHaveBeenCalled();
+    expect(getBalanceMock).not.toHaveBeenCalled();
+    expect(sendTransactionAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps the EVM send transaction request unchanged after the recheck passes', async () => {
+    const prepared = getPreparedBatch();
+    getBalanceMock.mockResolvedValue(prepared.totalValueAttoFil + 1_000_000n);
+
+    await act(async () => {
+      await latestHook?.executeBatch(recipientsWithFees, 'PARTIAL');
+    });
+
+    expect(estimateGasMock).toHaveBeenCalledWith({
+      to: prepared.batch.to,
+      data: prepared.batch.data,
+      value: prepared.batch.value,
+      account: ACCOUNT,
+    });
+    expect(sendTransactionAsyncMock).toHaveBeenCalledWith({
+      to: prepared.batch.to,
+      data: prepared.batch.data,
+      value: prepared.batch.value,
+    });
+  });
+});

--- a/src/lib/transaction/errorHandling.ts
+++ b/src/lib/transaction/errorHandling.ts
@@ -7,6 +7,8 @@ export type BatchExecutionErrorCategory =
   | 'SIMULATION_REVERT'
   | 'ONCHAIN_REVERT_ATOMIC'
   | 'RPC_FAILURE'
+  | 'UNSUPPORTED_NETWORK'
+  | 'UNSUPPORTED_SENDER'
   | 'UNKNOWN';
 
 export type BatchExecutionStage = 'preflight' | 'execution' | 'confirmation';

--- a/src/lib/transaction/submitBalanceCheck.ts
+++ b/src/lib/transaction/submitBalanceCheck.ts
@@ -1,0 +1,248 @@
+import type { Address } from 'viem';
+import type { ErrorMode } from './multicall';
+import { BatchExecutionError } from './errorHandling';
+import {
+  getSupportedNetworkListLabel,
+  type SendFilNetworkConfig,
+  type SupportedChainId,
+} from '../networks';
+
+type SubmitBalanceNetwork = Pick<
+  SendFilNetworkConfig,
+  'key' | 'chainId' | 'walletLabel'
+>;
+
+export type SubmitBalanceSender =
+  | {
+      kind: 'evm';
+      address: Address;
+      chainId: number;
+    }
+  | {
+      kind: 'native';
+      address: string;
+      networkKey: SendFilNetworkConfig['key'];
+    };
+
+export type SubmitBalanceCheckFailureReason =
+  | 'INSUFFICIENT_BALANCE'
+  | 'UNSUPPORTED_NETWORK'
+  | 'UNSUPPORTED_SENDER'
+  | 'BALANCE_UNAVAILABLE';
+
+interface SubmitBalanceCheckBase {
+  transferTotalAttoFil: bigint;
+  estimatedNetworkFeeAttoFil: bigint;
+  requiredAttoFil: bigint;
+}
+
+export interface SubmitBalanceCheckSuccess extends SubmitBalanceCheckBase {
+  ok: true;
+  availableAttoFil: bigint;
+}
+
+export interface SubmitBalanceCheckFailure extends SubmitBalanceCheckBase {
+  ok: false;
+  reason: SubmitBalanceCheckFailureReason;
+  availableAttoFil?: bigint;
+  details?: string;
+}
+
+export type SubmitBalanceCheckResult =
+  | SubmitBalanceCheckSuccess
+  | SubmitBalanceCheckFailure;
+
+export interface SubmitBalanceCheckRequest {
+  sender: SubmitBalanceSender;
+  network?: SubmitBalanceNetwork;
+  transferTotalAttoFil: bigint;
+  estimatedNetworkFeeAttoFil: bigint;
+  readEvmBalance?: (params: {
+    address: Address;
+    chainId: SupportedChainId;
+  }) => Promise<bigint>;
+  readNativeBalance?: (params: {
+    address: string;
+    networkKey: SendFilNetworkConfig['key'];
+  }) => Promise<bigint>;
+}
+
+function createBaseResult(
+  request: Pick<
+    SubmitBalanceCheckRequest,
+    'transferTotalAttoFil' | 'estimatedNetworkFeeAttoFil'
+  >,
+): SubmitBalanceCheckBase {
+  return {
+    transferTotalAttoFil: request.transferTotalAttoFil,
+    estimatedNetworkFeeAttoFil: request.estimatedNetworkFeeAttoFil,
+    requiredAttoFil:
+      request.transferTotalAttoFil + request.estimatedNetworkFeeAttoFil,
+  };
+}
+
+function createFailure(
+  request: Pick<
+    SubmitBalanceCheckRequest,
+    'transferTotalAttoFil' | 'estimatedNetworkFeeAttoFil'
+  >,
+  reason: SubmitBalanceCheckFailureReason,
+  options: Pick<SubmitBalanceCheckFailure, 'availableAttoFil' | 'details'> = {},
+): SubmitBalanceCheckFailure {
+  return {
+    ok: false,
+    ...createBaseResult(request),
+    reason,
+    ...options,
+  };
+}
+
+function createSuccess(
+  request: Pick<
+    SubmitBalanceCheckRequest,
+    'transferTotalAttoFil' | 'estimatedNetworkFeeAttoFil'
+  >,
+  availableAttoFil: bigint,
+): SubmitBalanceCheckSuccess {
+  return {
+    ok: true,
+    ...createBaseResult(request),
+    availableAttoFil,
+  };
+}
+
+export async function recheckSubmitBalance(
+  request: SubmitBalanceCheckRequest,
+): Promise<SubmitBalanceCheckResult> {
+  const { sender, network } = request;
+
+  if (!network) {
+    return createFailure(request, 'UNSUPPORTED_NETWORK', {
+      details: `Connect to ${getSupportedNetworkListLabel()} before submitting a batch.`,
+    });
+  }
+
+  if (sender.kind === 'evm') {
+    if (sender.chainId !== network.chainId) {
+      return createFailure(request, 'UNSUPPORTED_NETWORK', {
+        details: `Wallet is connected to chain ${sender.chainId}, but the active SendFIL network is ${network.walletLabel}.`,
+      });
+    }
+
+    if (!request.readEvmBalance) {
+      return createFailure(request, 'BALANCE_UNAVAILABLE', {
+        details: 'No EVM balance reader is available for the connected wallet.',
+      });
+    }
+
+    try {
+      const availableAttoFil = await request.readEvmBalance({
+        address: sender.address,
+        chainId: network.chainId,
+      });
+      const base = createBaseResult(request);
+
+      if (availableAttoFil < base.requiredAttoFil) {
+        return {
+          ok: false,
+          ...base,
+          reason: 'INSUFFICIENT_BALANCE',
+          availableAttoFil,
+        };
+      }
+
+      return createSuccess(request, availableAttoFil);
+    } catch (error) {
+      return createFailure(request, 'BALANCE_UNAVAILABLE', {
+        details: error instanceof Error ? error.message : 'Unknown balance read failure',
+      });
+    }
+  }
+
+  if (!request.readNativeBalance) {
+    return createFailure(request, 'UNSUPPORTED_SENDER', {
+      details:
+        'Submit-time balance checks for native Filecoin senders are not implemented yet.',
+    });
+  }
+
+  try {
+    const availableAttoFil = await request.readNativeBalance({
+      address: sender.address,
+      networkKey: sender.networkKey,
+    });
+    const base = createBaseResult(request);
+
+    if (availableAttoFil < base.requiredAttoFil) {
+      return {
+        ok: false,
+        ...base,
+        reason: 'INSUFFICIENT_BALANCE',
+        availableAttoFil,
+      };
+    }
+
+    return createSuccess(request, availableAttoFil);
+  } catch (error) {
+    return createFailure(request, 'BALANCE_UNAVAILABLE', {
+      details: error instanceof Error ? error.message : 'Unknown balance read failure',
+    });
+  }
+}
+
+export function createSubmitBalanceCheckError(
+  result: SubmitBalanceCheckFailure,
+  errorMode: ErrorMode,
+): BatchExecutionError {
+  switch (result.reason) {
+    case 'INSUFFICIENT_BALANCE':
+      return new BatchExecutionError({
+        category: 'INSUFFICIENT_FUNDS',
+        title: 'Balance changed',
+        message: 'Balance changed. Please review again.',
+        errorMode,
+        stage: 'execution',
+        recoverable: true,
+        hint:
+          'Your current balance is below the batch total plus the latest estimated network fee.',
+        details: `Required ${result.requiredAttoFil.toString()} attoFIL; available ${result.availableAttoFil?.toString() ?? 'unknown'} attoFIL.`,
+      });
+    case 'UNSUPPORTED_NETWORK':
+      return new BatchExecutionError({
+        category: 'UNSUPPORTED_NETWORK',
+        title: 'Unsupported network',
+        message: `Connect to ${getSupportedNetworkListLabel()} before submitting this batch.`,
+        errorMode,
+        stage: 'execution',
+        recoverable: true,
+        hint: 'Switch networks in your wallet, then review the batch again.',
+        details: result.details,
+      });
+    case 'UNSUPPORTED_SENDER':
+      return new BatchExecutionError({
+        category: 'UNSUPPORTED_SENDER',
+        title: 'Sender type not supported',
+        message:
+          'Submit-time balance checks are not implemented for this sender type yet.',
+        errorMode,
+        stage: 'execution',
+        recoverable: true,
+        hint:
+          'Use an EVM wallet for this batch until native Filecoin sender support is wired in.',
+        details: result.details,
+      });
+    case 'BALANCE_UNAVAILABLE':
+    default:
+      return new BatchExecutionError({
+        category: 'RPC_FAILURE',
+        title: 'Balance check unavailable',
+        message:
+          'SendFIL could not verify your balance on the active network before submitting.',
+        errorMode,
+        stage: 'execution',
+        recoverable: true,
+        hint: 'Retry in a moment. SendFIL will not submit until the balance check succeeds.',
+        details: result.details,
+      });
+  }
+}

--- a/src/lib/transaction/useExecuteBatch.ts
+++ b/src/lib/transaction/useExecuteBatch.ts
@@ -22,6 +22,10 @@ import {
   BatchExecutionError,
   mapBatchExecutionError,
 } from './errorHandling';
+import {
+  createSubmitBalanceCheckError,
+  recheckSubmitBalance,
+} from './submitBalanceCheck';
 import { emitBatchExecutionTelemetry } from './telemetry';
 import {
   getSupportedNetworkByChainId,
@@ -80,9 +84,9 @@ export function useExecuteBatch(
 
   const account = useAccount();
   const chainId = useChainId();
-  const publicClient = usePublicClient();
-  const { sendTransactionAsync } = useSendTransaction();
   const activeNetwork = getSupportedNetworkByChainId(chainId);
+  const publicClient = usePublicClient({ chainId: activeNetwork?.chainId });
+  const { sendTransactionAsync } = useSendTransaction();
 
   // Watch for transaction confirmation
   const { isLoading: isConfirming, isSuccess, isError: txError, error: receiptError } =
@@ -268,11 +272,41 @@ export function useExecuteBatch(
           simulationResult: errorMode === 'ATOMIC' ? 'passed' : 'skipped',
         });
 
-        if (errorMode === 'ATOMIC') {
-          await estimatePreparedBatch(prepared);
+        if (adapter) {
+          if (errorMode === 'ATOMIC') {
+            await estimatePreparedBatch(prepared);
+          }
+        } else {
+          const submitEstimate = await estimatePreparedBatch(prepared);
+          failureStage = 'execution';
+
+          if (!account.address) {
+            throw new Error('No connected EVM account available for submit-time balance check.');
+          }
+
+          const balanceCheck = await recheckSubmitBalance({
+            sender: {
+              kind: 'evm',
+              address: account.address,
+              chainId,
+            },
+            network: activeNetwork,
+            transferTotalAttoFil: prepared.totalValueAttoFil,
+            estimatedNetworkFeeAttoFil: submitEstimate.estimatedFee,
+            readEvmBalance: async ({ address: senderAddress }) => {
+              if (!publicClient) {
+                throw new Error('Public client not available');
+              }
+
+              return publicClient.getBalance({ address: senderAddress });
+            },
+          });
+
+          if (!balanceCheck.ok) {
+            throw createSubmitBalanceCheckError(balanceCheck, errorMode);
+          }
         }
 
-        failureStage = 'execution';
         setState('signing');
 
         const submission = adapter
@@ -344,7 +378,15 @@ export function useExecuteBatch(
         throw mappedError;
       }
     },
-    [activeNetwork, adapter, estimatePreparedBatch, sendTransactionAsync],
+    [
+      account.address,
+      activeNetwork,
+      adapter,
+      chainId,
+      estimatePreparedBatch,
+      publicClient,
+      sendTransactionAsync,
+    ],
   );
 
   /**


### PR DESCRIPTION
## Summary

Adds a submit-time balance guard for the live EVM/wagmi SendFIL path. The guard re-estimates the network fee, re-reads the connected sender balance on the active supported network, and blocks wallet submission if the current balance no longer covers the prepared batch transfer value plus the latest estimated network fee.

The new helper is sender-aware so future native Filecoin sender work can reuse it by passing a Lotus/native balance reader. Native sender submission remains explicitly unsupported in this patch; this PR does not introduce native f1/t1 wallet signing or refactor the wallet architecture.

## Validation

- `yarn test src/lib/transaction/__tests__`
- `yarn lint`
- targeted eslint for the touched transaction files

## Notes

Full local `yarn test` and `yarn typecheck` were not used as final gates because the worktree contains concurrent native-sender and app invariant changes outside this PR scope. The balance-recheck transaction tests pass in isolation and the PR stages only the balance-recheck files.