### PR TITLE
[codex] Harden Calibration FEVM batch path

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,10 @@ import UnavailableCapabilityModal from './components/UnavailableCapabilityModal'
 import { useAccount, useBalance, useChainId } from 'wagmi';
 import { formatUnits } from 'viem';
 import { calculateFeeRows, getFeeLabel } from './utils/fee';
-import { validateRecipientRows } from './utils/recipientValidation';
+import {
+  validateRecipientRows,
+  type RecipientValidationResult,
+} from './utils/recipientValidation';
 import {
   DEFAULT_BATCH_CONFIGURATION,
   getErrorHandlingLabel,
@@ -77,6 +80,15 @@ function createEmptyManualInteractions(count = 3): ManualRecipientInteraction[] 
     addressTouched: false,
     amountTouched: false,
   }));
+}
+
+function createEmptyRecipientValidationResult(): RecipientValidationResult {
+  return {
+    validRecipients: [],
+    errors: [],
+    warnings: [],
+    nonEmptyRowCount: 0,
+  };
 }
 
 function formatSummaryFil(amount: number): string {
@@ -474,6 +486,18 @@ export default function App() {
     [csvData],
   );
 
+  const csvValidation = React.useMemo(
+    () =>
+      csvData.length > 0
+        ? validateRecipientRows(csvRecipients, {
+            source: 'csv',
+            expectedNetworkPrefix,
+            requireAtLeastOneRecipient: true,
+          })
+        : createEmptyRecipientValidationResult(),
+    [csvData.length, csvRecipients, expectedNetworkPrefix],
+  );
+
   const hasEnteredData =
     inputMode === 'manual'
       ? manualValidation.nonEmptyRowCount > 0
@@ -510,13 +534,15 @@ export default function App() {
 
   const validRecipients = React.useMemo(
     () =>
-      (inputMode === 'manual' ? manualValidation.validRecipients : csvRecipients).map(
-        (recipient) => ({
-          address: recipient.address,
-          amount: Number(recipient.amount),
-        }),
-      ),
-    [csvRecipients, inputMode, manualValidation.validRecipients],
+      (
+        inputMode === 'manual'
+          ? manualValidation.validRecipients
+          : csvValidation.validRecipients
+      ).map((recipient) => ({
+        address: recipient.address,
+        amount: Number(recipient.amount),
+      })),
+    [csvValidation.validRecipients, inputMode, manualValidation.validRecipients],
   );
   const selectedErrorMode: ErrorHandlingPreference = 'PARTIAL';
   const feeComputation = React.useMemo(() => {
@@ -566,14 +592,25 @@ export default function App() {
         ]
       : [
           ...csvErrors,
+          ...csvValidation.errors,
           ...(feeComputation.error ? [feeComputation.error] : []),
           ...networkValidationErrors,
         ];
+  const activeBlockingValidationErrors =
+    inputMode === 'manual'
+      ? [
+          ...manualValidation.errors,
+          ...(feeComputation.error ? [feeComputation.error] : []),
+          ...networkValidationErrors,
+        ]
+      : activeValidationErrors;
   const activeValidationWarnings =
-    inputMode === 'manual' ? manualValidation.warnings : csvWarnings;
+    inputMode === 'manual'
+      ? manualValidation.warnings
+      : [...csvWarnings, ...csvValidation.warnings];
 
   const draftRecipientCount =
-    inputMode === 'manual' ? manualValidation.nonEmptyRowCount : csvData.length;
+    inputMode === 'manual' ? manualValidation.nonEmptyRowCount : csvValidation.nonEmptyRowCount;
   const hasReviewableRows = draftRecipientCount > 0;
 
   const recipientTotal = validRecipients.reduce((sum, recipient) => sum + recipient.amount, 0);
@@ -688,7 +725,7 @@ export default function App() {
       return;
     }
 
-    if (validRecipients.length > 0 && activeValidationErrors.length === 0) {
+    if (validRecipients.length > 0 && activeBlockingValidationErrors.length === 0) {
       setIsEstimatingGas(true);
 
       try {
@@ -732,6 +769,15 @@ export default function App() {
   };
 
   const handleConfirmTransaction = async () => {
+    if (
+      !isConnected ||
+      !address ||
+      isNetworkMismatch ||
+      activeBlockingValidationErrors.length > 0
+    ) {
+      return;
+    }
+
     try {
       await executeBatch(feeComputation.recipients, selectedErrorMode);
     } catch {
@@ -1193,7 +1239,10 @@ f1cj...,3.3`;
                         messages={[
                           `${csvData.length} recipients imported from the uploaded file.`,
                           `Current valid total: ${formatSummaryFil(
-                            csvData.reduce((sum, recipient) => sum + Number(recipient.value), 0),
+                            csvValidation.validRecipients.reduce(
+                              (sum, recipient) => sum + Number(recipient.amount),
+                              0,
+                            ),
                           )}.`,
                         ]}
                         tone="info"

--- a/src/__tests__/app.invariants.test.tsx
+++ b/src/__tests__/app.invariants.test.tsx
@@ -4,7 +4,10 @@ import { JSDOM } from 'jsdom';
 import { createRoot, type Root } from 'react-dom/client';
 import { getAddress } from 'viem';
 import App from '../App';
-import type { RecipientValidationResult } from '../utils/recipientValidation';
+import {
+  validateRecipientRows,
+  type RecipientValidationResult,
+} from '../utils/recipientValidation';
 
 const FEE_A = '0x1111111111111111111111111111111111111111';
 const FEE_B = '0x2222222222222222222222222222222222222222';
@@ -186,6 +189,66 @@ describe('INV-NET-001 wrong network gating', () => {
     expect(estimateBatchMock).not.toHaveBeenCalled();
     expect(executeBatchMock).not.toHaveBeenCalled();
     expect(container.textContent).not.toContain('Review Batch');
+  });
+
+  it('allows the current EVM sender path on Calibration without default fee rows', async () => {
+    mockChainId = 314159;
+
+    await act(async () => {
+      root.render(<App />);
+    });
+
+    expect(vi.mocked(validateRecipientRows)).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({
+        source: 'manual',
+        expectedNetworkPrefix: 't',
+      }),
+    );
+
+    click(getElementByTestId(container, 'review-batch-button'));
+    await flushAsyncWork();
+
+    expect(container.textContent).toContain('Calibration Testnet');
+    expect(estimateBatchMock).toHaveBeenCalledWith(
+      [{ address: getAddress(RECIPIENT), amount: 1 }],
+      'PARTIAL',
+    );
+
+    click(getElementByTestId(container, 'send-batch-button'));
+    await flushAsyncWork();
+
+    expect(executeBatchMock).toHaveBeenCalledWith(
+      [{ address: getAddress(RECIPIENT), amount: 1 }],
+      'PARTIAL',
+    );
+  });
+
+  it('keeps Calibration wrong-prefix batches from estimating or sending', async () => {
+    const wrongPrefixRecipient = 'f1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za';
+    mockChainId = 314159;
+    mockValidationResult = {
+      validRecipients: [],
+      errors: [
+        `${wrongPrefixRecipient} does not match the current Calibration address format`,
+      ],
+      warnings: [],
+      nonEmptyRowCount: 1,
+    };
+
+    await act(async () => {
+      root.render(<App />);
+    });
+
+    click(getElementByTestId(container, 'review-batch-button'));
+    await flushAsyncWork();
+
+    expect(container.textContent).toContain(
+      `${wrongPrefixRecipient} does not match the current Calibration address format`,
+    );
+    expect(getElementByTestId(container, 'send-batch-button')).toHaveProperty('disabled', true);
+    expect(estimateBatchMock).not.toHaveBeenCalled();
+    expect(executeBatchMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/CSVUpload.tsx
+++ b/src/components/CSVUpload.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useState } from 'react';
 import Papa, { type ParseResult } from 'papaparse';
-import { validateRecipientRows } from '../utils/recipientValidation';
 
 export interface CSVRecipient {
   receiverAddress: string;
@@ -84,35 +83,10 @@ export const CSVUpload: React.FC<CSVUploadProps> = ({
               });
             }
 
-            const validationResult =
-              errors.length === 0
-                ? validateRecipientRows(
-                    parsedRecipients.map((recipient) => ({
-                      address: recipient.receiverAddress,
-                      amount: recipient.value,
-                      lineNumber: recipient.lineNumber,
-                    })),
-                    {
-                      source: 'csv',
-                      expectedNetworkPrefix,
-                      requireAtLeastOneRecipient: true,
-                    },
-                  )
-                : {
-                    validRecipients: [],
-                    errors: [],
-                    warnings: [],
-                    nonEmptyRowCount: 0,
-                  };
-
             onUpload({
-              recipients: validationResult.validRecipients.map((recipient) => ({
-                receiverAddress: recipient.address,
-                value: recipient.amount,
-                lineNumber: recipient.lineNumber,
-              })),
-              errors: [...errors, ...validationResult.errors],
-              warnings: validationResult.warnings,
+              recipients: errors.length === 0 ? parsedRecipients : [],
+              errors,
+              warnings: [],
             });
             setIsProcessing(false);
           },
@@ -136,7 +110,7 @@ export const CSVUpload: React.FC<CSVUploadProps> = ({
         setIsProcessing(false);
       }
     },
-    [expectedNetworkPrefix, onUpload],
+    [onUpload],
   );
 
   const handleDrop = useCallback(

--- a/src/lib/__tests__/networks.test.ts
+++ b/src/lib/__tests__/networks.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  SUPPORTED_WAGMI_CHAINS,
   getDefaultNetworkKey,
   getFilfoxMessageUrl,
   getNetworkConfig,
@@ -16,6 +17,18 @@ describe('networks', () => {
     expect(getSupportedNetworkByChainId(314)?.key).toBe('mainnet');
     expect(getSupportedNetworkByChainId(314159)?.key).toBe('calibration');
     expect(getSupportedNetworkByChainId(1)).toBeUndefined();
+  });
+
+  it('exposes both Filecoin chains to wagmi', () => {
+    expect(SUPPORTED_WAGMI_CHAINS.map((chain) => chain.id)).toEqual([314, 314159]);
+  });
+
+  it('resolves FEVM RPC URLs per supported network', () => {
+    vi.stubEnv('VITE_FEVM_RPC_URL_MAINNET', 'http://fevm-mainnet');
+    vi.stubEnv('VITE_FEVM_RPC_URL_CALIBRATION', 'http://fevm-calibration');
+
+    expect(getNetworkConfig('mainnet').fevmRpcUrl).toBe('http://fevm-mainnet');
+    expect(getNetworkConfig('calibration').fevmRpcUrl).toBe('http://fevm-calibration');
   });
 
   it('builds Filfox message URLs for both supported networks', () => {
@@ -43,6 +56,18 @@ describe('networks', () => {
     expect(mainnet.feePolicy.recipientA).toBe('f1mainfeea');
     expect(mainnet.feePolicy.recipientB).toBe('f1mainfeeb');
     expect(calibration.feePolicy.enabled).toBe(false);
+  });
+
+  it('enables calibration fees only when the calibration env says so', () => {
+    vi.stubEnv('VITE_FEE_ENABLED_CALIBRATION', 'true');
+    vi.stubEnv('VITE_FEE_ADDR_A_CALIBRATION', 't1fee-a');
+    vi.stubEnv('VITE_FEE_ADDR_B_CALIBRATION', 't1fee-b');
+
+    const calibration = getNetworkConfig('calibration');
+
+    expect(calibration.feePolicy.enabled).toBe(true);
+    expect(calibration.feePolicy.recipientA).toBe('t1fee-a');
+    expect(calibration.feePolicy.recipientB).toBe('t1fee-b');
   });
 
   it('resolves lotus rpc config per network', () => {

--- a/src/lib/transaction/__tests__/batchExecution.test.ts
+++ b/src/lib/transaction/__tests__/batchExecution.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, it } from 'vitest';
-import { getDefaultNetworkConfig } from '../../networks';
+import { getAddress } from 'viem';
+import {
+  CoinType,
+  newActorAddress,
+  newBLSAddress,
+  newSecp256k1Address,
+} from '@glif/filecoin-address';
+import { toF4 } from '../../../utils/toF4';
+import { getDefaultNetworkConfig, getNetworkConfig } from '../../networks';
 import { prepareBatchExecution } from '../batchExecution';
+
+const EVM_RECIPIENT = '0x1234567890abcdef1234567890abcdef12345678';
+const CALIBRATION_T1 = newSecp256k1Address(
+  Uint8Array.from({ length: 33 }, (_, index) => index + 1),
+  CoinType.TEST,
+).toString();
+const CALIBRATION_T2 = newActorAddress(Uint8Array.from([1, 2, 3, 4]), CoinType.TEST).toString();
+const CALIBRATION_T3 = newBLSAddress(
+  Uint8Array.from({ length: 48 }, (_, index) => index + 10),
+  CoinType.TEST,
+).toString();
 
 describe('INV-EXEC-001 prepared batch determinism', () => {
   it('produces the same prepared execution config for estimate and submit inputs', () => {
@@ -30,5 +49,63 @@ describe('INV-EXEC-001 prepared batch determinism', () => {
       },
     });
     expect(preparedForEstimate.batch.data).toBe(preparedForSubmit.batch.data);
+  });
+
+  it('prepares the current Calibration EVM sender recipient matrix with network metadata', () => {
+    const network = getNetworkConfig('calibration');
+    const calibrationT4 = toF4(EVM_RECIPIENT, 't');
+    const recipients = [
+      { address: EVM_RECIPIENT, amount: 1 },
+      { address: calibrationT4, amount: 2 },
+      { address: CALIBRATION_T1, amount: 3 },
+      { address: CALIBRATION_T2, amount: 4 },
+      { address: CALIBRATION_T3, amount: 5 },
+    ];
+
+    const prepared = prepareBatchExecution(recipients, 'PARTIAL', network);
+
+    expect(prepared).toMatchObject({
+      errorMode: 'PARTIAL',
+      recipients,
+      recipientCount: 5,
+      networkKey: 'calibration',
+      chainId: 314159,
+    });
+    expect(prepared.batch.to).toBe(network.multicall3Address);
+    expect(prepared.batch.value).toBe(15_000_000_000_000_000_000n);
+    expect(prepared.batch.calls[0]).toMatchObject({
+      target: getAddress(EVM_RECIPIENT),
+      allowFailure: true,
+      value: 1_000_000_000_000_000_000n,
+      callData: '0x',
+    });
+    expect(prepared.batch.calls[1]).toMatchObject({
+      target: getAddress(EVM_RECIPIENT),
+      allowFailure: true,
+      value: 2_000_000_000_000_000_000n,
+      callData: '0x',
+    });
+    expect(prepared.batch.calls.slice(2).every((call) => call.target === network.filForwarderAddress))
+      .toBe(true);
+    expect(prepared.batch.calls.slice(2).every((call) => call.callData !== '0x')).toBe(true);
+  });
+
+  it('uses the active network contract addresses when preparing a batch', () => {
+    const network = {
+      ...getNetworkConfig('calibration'),
+      multicall3Address: '0x3333333333333333333333333333333333333333' as const,
+      filForwarderAddress: '0x4444444444444444444444444444444444444444' as const,
+    };
+
+    const prepared = prepareBatchExecution(
+      [{ address: CALIBRATION_T1, amount: 1 }],
+      'PARTIAL',
+      network,
+    );
+
+    expect(prepared.batch.to).toBe(network.multicall3Address);
+    expect(prepared.batch.calls[0]?.target).toBe(network.filForwarderAddress);
+    expect(prepared.networkKey).toBe('calibration');
+    expect(prepared.chainId).toBe(314159);
   });
 });

--- a/src/utils/__tests__/fee.test.ts
+++ b/src/utils/__tests__/fee.test.ts
@@ -1,6 +1,18 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CoinType, newSecp256k1Address } from '@glif/filecoin-address';
 import { getNetworkConfig } from '../../lib/networks';
 import { calculateFeeRows, getFeeLabel } from '../fee';
+
+const MAINNET_FEE_A = '0x1111111111111111111111111111111111111111';
+const MAINNET_FEE_B = '0x2222222222222222222222222222222222222222';
+const CALIBRATION_FEE_A = newSecp256k1Address(
+  Uint8Array.from({ length: 33 }, (_, index) => index + 1),
+  CoinType.TEST,
+).toString();
+const CALIBRATION_FEE_B = newSecp256k1Address(
+  Uint8Array.from({ length: 33 }, (_, index) => index + 40),
+  CoinType.TEST,
+).toString();
 
 describe('calculateFeeRows', () => {
   afterEach(() => {
@@ -8,8 +20,8 @@ describe('calculateFeeRows', () => {
   });
 
   it('appends fee rows on mainnet when fees are enabled', () => {
-    vi.stubEnv('VITE_FEE_ADDR_A_MAINNET', 'f1mainfeea');
-    vi.stubEnv('VITE_FEE_ADDR_B_MAINNET', 'f1mainfeeb');
+    vi.stubEnv('VITE_FEE_ADDR_A_MAINNET', MAINNET_FEE_A);
+    vi.stubEnv('VITE_FEE_ADDR_B_MAINNET', MAINNET_FEE_B);
     vi.stubEnv('VITE_FEE_PERCENT_MAINNET', '1');
     vi.stubEnv('VITE_FEE_SPLIT_MAINNET', '0.5');
 
@@ -24,8 +36,8 @@ describe('calculateFeeRows', () => {
     expect(result).toEqual([
       { address: 'f1user1', amount: 100 },
       { address: 'f1user2', amount: 100 },
-      { address: 'f1mainfeea', amount: 1 },
-      { address: 'f1mainfeeb', amount: 1 },
+      { address: MAINNET_FEE_A, amount: 1 },
+      { address: MAINNET_FEE_B, amount: 1 },
     ]);
   });
 
@@ -36,12 +48,42 @@ describe('calculateFeeRows', () => {
     expect(getFeeLabel(314159)).toBe('Platform fee (disabled on testnet)');
   });
 
-  it('throws if an enabled fee address is already present', () => {
-    vi.stubEnv('VITE_FEE_ADDR_A_MAINNET', 'f1mainfeea');
-    vi.stubEnv('VITE_FEE_ADDR_B_MAINNET', 'f1mainfeeb');
+  it('appends Calibration fee rows only when explicitly enabled', () => {
+    vi.stubEnv('VITE_FEE_ENABLED_CALIBRATION', 'true');
+    vi.stubEnv('VITE_FEE_ADDR_A_CALIBRATION', CALIBRATION_FEE_A);
+    vi.stubEnv('VITE_FEE_ADDR_B_CALIBRATION', CALIBRATION_FEE_B);
+
+    const result = calculateFeeRows(
+      [{ address: '0x1234567890abcdef1234567890abcdef12345678', amount: 10 }],
+      getNetworkConfig('calibration'),
+    );
+
+    expect(result).toEqual([
+      { address: '0x1234567890abcdef1234567890abcdef12345678', amount: 10 },
+      { address: CALIBRATION_FEE_A, amount: 0.05 },
+      { address: CALIBRATION_FEE_B, amount: 0.05 },
+    ]);
+  });
+
+  it('rejects wrong-prefix fee addresses when Calibration fees are enabled', () => {
+    vi.stubEnv('VITE_FEE_ENABLED_CALIBRATION', 'true');
+    vi.stubEnv('VITE_FEE_ADDR_A_CALIBRATION', CALIBRATION_FEE_A);
+    vi.stubEnv('VITE_FEE_ADDR_B_CALIBRATION', 'f1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za');
 
     expect(() =>
-      calculateFeeRows([{ address: 'f1mainfeea', amount: 1 }], getNetworkConfig('mainnet')),
+      calculateFeeRows(
+        [{ address: '0x1234567890abcdef1234567890abcdef12345678', amount: 10 }],
+        getNetworkConfig('calibration'),
+      ),
+    ).toThrow('does not match the current Calibration address format');
+  });
+
+  it('throws if an enabled fee address is already present', () => {
+    vi.stubEnv('VITE_FEE_ADDR_A_MAINNET', MAINNET_FEE_A);
+    vi.stubEnv('VITE_FEE_ADDR_B_MAINNET', MAINNET_FEE_B);
+
+    expect(() =>
+      calculateFeeRows([{ address: MAINNET_FEE_A, amount: 1 }], getNetworkConfig('mainnet')),
     ).toThrow('Fee address included in recipient list');
   });
 });

--- a/src/utils/__tests__/recipientValidation.test.ts
+++ b/src/utils/__tests__/recipientValidation.test.ts
@@ -37,6 +37,16 @@ const CALIBRATION_T1 = newSecp256k1Address(
   CoinType.TEST,
 ).toString();
 
+const CALIBRATION_T2 = newActorAddress(
+  Uint8Array.from([4, 3, 2, 1]),
+  CoinType.TEST,
+).toString();
+
+const CALIBRATION_T3 = newBLSAddress(
+  Uint8Array.from({ length: 48 }, (_, index) => index + 70),
+  CoinType.TEST,
+).toString();
+
 const ZERO_X_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
 const TWIN_ZERO_X_ADDRESS = '0xe764Acf02D8B7c21d2B6A8f0a96C78541e0DC3fd';
 
@@ -319,17 +329,40 @@ describe('network-aware validation regression coverage', () => {
     ]);
   });
 
-  it('accepts Calibration-native recipients in the testnet flow', () => {
+  it('rejects mainnet prefixes in the Calibration flow', () => {
+    const result = validateRecipientRows(
+      [{ address: MAINNET_F1, amount: '1' }],
+      { source: 'manual', expectedNetworkPrefix: 't' },
+    );
+
+    expect(result.errors).toEqual([
+      `Recipient 1: ${MAINNET_F1} does not match the current Calibration address format`,
+    ]);
+    expect(result.validRecipients).toEqual([]);
+  });
+
+  it('accepts Calibration t1, t2, t3, t4, and 0x recipients in the testnet flow', () => {
+    const calibrationT4 = toF4(TWIN_ZERO_X_ADDRESS, 't');
+
     const result = validateRecipientRows(
       [
         { address: CALIBRATION_T1, amount: '1' },
-        { address: toF4(TWIN_ZERO_X_ADDRESS, 't'), amount: '2' },
+        { address: CALIBRATION_T2, amount: '2' },
+        { address: CALIBRATION_T3, amount: '3' },
+        { address: calibrationT4, amount: '4' },
+        { address: ZERO_X_ADDRESS, amount: '5' },
       ],
       { source: 'manual', expectedNetworkPrefix: 't' },
     );
 
     expect(result.errors).toEqual([]);
-    expect(result.validRecipients).toHaveLength(2);
+    expect(result.validRecipients).toEqual([
+      { address: CALIBRATION_T1, amount: '1', lineNumber: 1 },
+      { address: CALIBRATION_T2, amount: '2', lineNumber: 2 },
+      { address: CALIBRATION_T3, amount: '3', lineNumber: 3 },
+      { address: calibrationT4, amount: '4', lineNumber: 4 },
+      { address: getAddress(ZERO_X_ADDRESS), amount: '5', lineNumber: 5 },
+    ]);
   });
 
   it('blocks mixed mainnet and Calibration native prefixes while disconnected', () => {

--- a/src/utils/fee.ts
+++ b/src/utils/fee.ts
@@ -4,6 +4,7 @@ import {
   getNetworkConfig,
   getSupportedNetworkByChainId,
 } from '../lib/networks';
+import { validateRecipientRows } from './recipientValidation';
 
 export interface Recipient {
   address: string;
@@ -12,12 +13,33 @@ export interface Recipient {
 
 function validateFeePolicy(
   feePolicy: SendFilFeePolicy,
+  nativePrefix: SendFilNetworkConfig['nativePrefix'],
 ): asserts feePolicy is SendFilFeePolicy & {
   recipientA: string;
   recipientB: string;
 } {
   if (!feePolicy.recipientA || !feePolicy.recipientB) {
     throw new Error('Fee addresses are not configured for the active network');
+  }
+
+  const validation = validateRecipientRows(
+    [
+      { address: feePolicy.recipientA, amount: '1' },
+      { address: feePolicy.recipientB, amount: '1' },
+    ],
+    {
+      source: 'manual',
+      expectedNetworkPrefix: nativePrefix,
+      maxRecipients: 2,
+    },
+  );
+
+  if (validation.errors.length > 0) {
+    throw new Error(
+      `Invalid fee address configuration: ${validation.errors
+        .map((error) => error.replace(/^Recipient \d+:\s*/, ''))
+        .join('; ')}`,
+    );
   }
 }
 
@@ -42,7 +64,7 @@ export function getFeeLabel(
 
 export function calculateFeeRows(
   recipients: Recipient[],
-  network: Pick<SendFilNetworkConfig, 'feePolicy'>,
+  network: Pick<SendFilNetworkConfig, 'feePolicy' | 'nativePrefix'>,
 ): Recipient[] {
   const feePolicy = network.feePolicy;
 
@@ -50,7 +72,7 @@ export function calculateFeeRows(
     return recipients;
   }
 
-  validateFeePolicy(feePolicy);
+  validateFeePolicy(feePolicy, network.nativePrefix);
 
   if (
     recipients.some(


### PR DESCRIPTION
## Summary

- Revalidates parsed CSV recipients in `App` against the currently connected network, so chain changes cannot leave stale CSV validation in place.
- Blocks FEVM review/send work from estimating or submitting when active blocking validation errors exist.
- Validates enabled platform fee addresses through the shared recipient validator, including active network prefix checks.
- Expands tests for Calibration FEVM behavior:
  - supported wagmi chains and network-specific FEVM RPC config
  - Calibration fee defaults and explicit fee enablement
  - wrong-prefix rejection on Calibration
  - `0x`, `t4`, `t1`, `t2`, and `t3` recipient preparation
  - active-network Multicall3 / FilForwarder metadata in prepared batches

## Scope Notes

This stays on the existing EVM/wagmi FEVM sender path only. Native Filecoin sender connectivity (`f1/t1` wallets), Ledger, Snap, Glif-native wallet, and native signer abstractions remain out of scope.

`PARTIAL` remains the default execution mode, and this does not introduce a separate `aggregate3` path.

## Testing

- [x] `yarn test`
- [x] `yarn test:e2e:smoke`
- [x] `yarn eslint src/App.tsx src/components/CSVUpload.tsx src/utils/fee.ts src/utils/__tests__/recipientValidation.test.ts src/utils/__tests__/fee.test.ts src/lib/__tests__/networks.test.ts src/lib/transaction/__tests__/batchExecution.test.ts src/__tests__/app.invariants.test.tsx --max-warnings=0`

## Known Local Worktree Note

Full `yarn lint` and `yarn typecheck` were blocked locally by unrelated native sender scaffold changes in `src/lib/senders/nativeFilecoinProvider.ts`, which are not part of this FEVM Calibration PR branch.