### PR TITLE
[codex] Add native Filecoin sender foundation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import {
   getSupportedNetworkByChainId,
   getSupportedNetworkListLabel,
 } from './lib/networks';
+import { createEvmConnectedSender } from './lib/senders';
 
 interface Recipient {
   address: string;
@@ -301,19 +302,36 @@ function ConfigurationChoiceGroup({
 export default function App() {
   const account = useAccount();
   const walletChainId = useChainId();
-  const isConnected = E2E_MOCK_WALLET_ENABLED ? true : account.isConnected;
-  const address = E2E_MOCK_WALLET_ENABLED ? E2E_MOCK_ACCOUNT : account.address;
-  const chainId = E2E_MOCK_WALLET_ENABLED ? E2E_MOCK_CHAIN_ID : walletChainId;
-  const detectedNetwork = getSupportedNetworkByChainId(chainId);
-  const connectedNetwork = isConnected ? detectedNetwork : undefined;
-  const hasSupportedConnectedNetwork = isConnected && Boolean(connectedNetwork);
-  const isUnsupportedConnectedNetwork = isConnected && !detectedNetwork;
+  const connectedSender = React.useMemo(
+    () =>
+      createEvmConnectedSender({
+        address: E2E_MOCK_WALLET_ENABLED ? E2E_MOCK_ACCOUNT : account.address,
+        chainId: E2E_MOCK_WALLET_ENABLED ? E2E_MOCK_CHAIN_ID : walletChainId,
+        isConnected: E2E_MOCK_WALLET_ENABLED ? true : account.isConnected,
+      }),
+    [account.address, account.isConnected, walletChainId],
+  );
+  const isConnected = Boolean(connectedSender);
+  const address = connectedSender?.address;
+  const chainId = connectedSender?.chainId;
+  const connectedNetwork = connectedSender?.network;
+  const hasSupportedConnectedNetwork =
+    isConnected && connectedSender?.networkStatus === 'supported';
+  const isUnsupportedConnectedNetwork =
+    isConnected && connectedSender?.networkStatus === 'unsupported';
   const expectedNetworkPrefix = connectedNetwork?.nativePrefix;
   const feeLabel = getFeeLabel(connectedNetwork?.chainId);
   const { data: balanceData } = useBalance({
-    address: account.address,
+    address: connectedSender?.kind === 'evm' ? connectedSender.address : undefined,
     chainId: connectedNetwork?.chainId,
-    query: { enabled: Boolean(account.address && hasSupportedConnectedNetwork) },
+    query: {
+      enabled: Boolean(
+        connectedSender?.kind === 'evm' &&
+          connectedSender.address &&
+          hasSupportedConnectedNetwork &&
+          !E2E_MOCK_WALLET_ENABLED,
+      ),
+    },
   });
 
   const [inputMode, setInputMode] = React.useState<InputMode>('manual');

--- a/src/lib/DataProvider/__tests__/DataProvider.test.ts
+++ b/src/lib/DataProvider/__tests__/DataProvider.test.ts
@@ -73,4 +73,16 @@ describe('DataProvider', () => {
       timeout: 50,
     });
   });
+
+  it('should read balances from the requested network rpc lane', async () => {
+    server.use(
+      http.post(CALIBRATION_PRIMARY, () =>
+        HttpResponse.json({ jsonrpc: '2.0', id: 1, result: '456' }),
+      ),
+    );
+
+    const result = await DataProvider.getBalance('t1sender', 'calibration');
+
+    expect(result).toBe('456');
+  });
 });

--- a/src/lib/DataProvider/index.ts
+++ b/src/lib/DataProvider/index.ts
@@ -6,56 +6,76 @@ import type {
   TipSet,
   TransactionStatus,
 } from './types';
+import type { SendFilNetworkKey } from '../networks';
 
 /** Filecoin.WalletBalance */
-export const getBalance = (address: string) =>
-  callRpc<string>('Filecoin.WalletBalance', [address]);
+export const getBalance = (address: string, networkKey?: SendFilNetworkKey) =>
+  callRpc<string>('Filecoin.WalletBalance', [address], networkKey);
 
 /** Filecoin.MpoolGetNonce */
-export const getNonce = (address: string) =>
-  callRpc<number>('Filecoin.MpoolGetNonce', [address]);
+export const getNonce = (address: string, networkKey?: SendFilNetworkKey) =>
+  callRpc<number>('Filecoin.MpoolGetNonce', [address], networkKey);
 
 /** Filecoin.ChainHead – useful for health checks */
-export const getChainHead = () =>
-  callRpc<{ Height: number; Cids: { '/': string }[] }>('Filecoin.ChainHead'); 
+export const getChainHead = (networkKey?: SendFilNetworkKey) =>
+  callRpc<{ Height: number; Cids: { '/': string }[] }>('Filecoin.ChainHead', [], networkKey);
 
 /** Filecoin.GasEstimateMessageGas - Estimate gas for a message */
-export const estimateGas = (message: FilecoinMessage, spec?: unknown) =>
-  callRpc<FilecoinMessage>('Filecoin.GasEstimateMessageGas', [message, spec, []]);
+export const estimateGas = (
+  message: FilecoinMessage,
+  spec?: unknown,
+  networkKey?: SendFilNetworkKey,
+) =>
+  callRpc<FilecoinMessage>('Filecoin.GasEstimateMessageGas', [message, spec, []], networkKey);
 
 /** Filecoin.MpoolPush - Submit signed message to mempool */
-export const submitTransaction = (signedMessage: SignedMessage) =>
-  callRpc<{ '/': string }>('Filecoin.MpoolPush', [signedMessage]);
+export const submitTransaction = (
+  signedMessage: SignedMessage,
+  networkKey?: SendFilNetworkKey,
+) =>
+  callRpc<{ '/': string }>('Filecoin.MpoolPush', [signedMessage], networkKey);
 
 /** Filecoin.StateSearchMsg - Search for message by CID */
-export const searchMessage = (cid: { '/': string }) =>
+export const searchMessage = (cid: { '/': string }, networkKey?: SendFilNetworkKey) =>
   callRpc<{
     Message: { '/': string };
     Receipt: MessageReceipt;
     ReturnDec: unknown;
     TipSet: { '/': string };
     Height: number;
-  } | null>('Filecoin.StateSearchMsg', [null, cid, -1, true]);
+  } | null>('Filecoin.StateSearchMsg', [null, cid, -1, true], networkKey);
 
 /** Filecoin.StateGetReceipt - Get receipt for message CID */
-export const getTransactionReceipt = (cid: { '/': string }) =>
-  callRpc<MessageReceipt>('Filecoin.StateGetReceipt', [cid, null]);
+export const getTransactionReceipt = (
+  cid: { '/': string },
+  networkKey?: SendFilNetworkKey,
+) =>
+  callRpc<MessageReceipt>('Filecoin.StateGetReceipt', [cid, null], networkKey);
 
 /** Filecoin.ChainGetTipSet - Get tipset by key */
-export const getTipSet = (tipsetKey: Array<{ '/': string }>) =>
-  callRpc<TipSet>('Filecoin.ChainGetTipSet', [tipsetKey]);
+export const getTipSet = (
+  tipsetKey: Array<{ '/': string }>,
+  networkKey?: SendFilNetworkKey,
+) =>
+  callRpc<TipSet>('Filecoin.ChainGetTipSet', [tipsetKey], networkKey);
 
 /** Filecoin.MpoolPending - Get pending messages from mempool */
-export const getPendingMessages = (address?: string) =>
-  callRpc<FilecoinMessage[]>('Filecoin.MpoolPending', [address ? [address] : []]);
+export const getPendingMessages = (
+  address?: string,
+  networkKey?: SendFilNetworkKey,
+) =>
+  callRpc<FilecoinMessage[]>('Filecoin.MpoolPending', [address ? [address] : []], networkKey);
 
 /** Helper: Check transaction status by CID */
-export const getTransactionStatus = async (cidString: string): Promise<TransactionStatus> => {
+export const getTransactionStatus = async (
+  cidString: string,
+  networkKey?: SendFilNetworkKey,
+): Promise<TransactionStatus> => {
   try {
     const cid = { '/': cidString };
     
     // First try to find the message
-    const searchResult = await searchMessage(cid);
+    const searchResult = await searchMessage(cid, networkKey);
     
     if (searchResult) {
       // Message found and executed
@@ -85,10 +105,11 @@ export const getTransactionStatus = async (cidString: string): Promise<Transacti
 export const pollTransactionStatus = async (
   cidString: string,
   maxAttempts: number = 60,
-  intervalMs: number = 5000
+  intervalMs: number = 5000,
+  networkKey?: SendFilNetworkKey,
 ): Promise<TransactionStatus> => {
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    const status = await getTransactionStatus(cidString);
+    const status = await getTransactionStatus(cidString, networkKey);
     
     if (status.status !== 'pending') {
       return status;

--- a/src/lib/senders/__tests__/nativeFilecoinProvider.test.ts
+++ b/src/lib/senders/__tests__/nativeFilecoinProvider.test.ts
@@ -1,0 +1,59 @@
+import {
+  CoinType,
+  newSecp256k1Address,
+} from '@glif/filecoin-address';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  getNativeFilecoinSenderBalanceAttoFil,
+  getNativeFilecoinWalletProviders,
+  NATIVE_FILECOIN_PROVIDER_PLACEHOLDER_METADATA,
+} from '../nativeFilecoinProvider';
+import { createNativeFilecoinConnectedSender } from '../senderModel';
+
+const CALIBRATION_T1 = newSecp256k1Address(
+  Uint8Array.from({ length: 33 }, (_, index) => index + 40),
+  CoinType.TEST,
+).toString();
+
+describe('native Filecoin provider boundary', () => {
+  it('keeps native Filecoin providers hidden while the feature flag is disabled', () => {
+    expect(getNativeFilecoinWalletProviders({ featureEnabled: false })).toEqual([]);
+  });
+
+  it('exposes only an unsupported placeholder when the feature flag is enabled', async () => {
+    const [provider] = getNativeFilecoinWalletProviders({ featureEnabled: true });
+
+    expect(provider.metadata).toMatchObject({
+      id: 'native-filecoin-placeholder',
+      kind: 'native-filecoin-wallet',
+      status: 'planned',
+      capabilities: {
+        canConnect: false,
+        canSignBatch: false,
+        canSubmit: false,
+        oneApprovalPerBatch: true,
+      },
+    });
+    await expect(provider.connect()).rejects.toThrow(
+      'Native Filecoin wallet signing is scaffolded',
+    );
+  });
+
+  it('reads native sender balances on the sender network', async () => {
+    const senderResult = createNativeFilecoinConnectedSender({
+      address: CALIBRATION_T1,
+      provider: NATIVE_FILECOIN_PROVIDER_PLACEHOLDER_METADATA,
+    });
+    const readBalance = vi.fn(async () => '123');
+
+    expect(senderResult.sender).toBeDefined();
+
+    const balance = await getNativeFilecoinSenderBalanceAttoFil(
+      senderResult.sender!,
+      readBalance,
+    );
+
+    expect(balance).toBe(123n);
+    expect(readBalance).toHaveBeenCalledWith(CALIBRATION_T1, 'calibration');
+  });
+});

--- a/src/lib/senders/__tests__/senderModel.test.ts
+++ b/src/lib/senders/__tests__/senderModel.test.ts
@@ -1,0 +1,142 @@
+import {
+  CoinType,
+  newActorAddress,
+  newBLSAddress,
+  newSecp256k1Address,
+} from '@glif/filecoin-address';
+import { getAddress } from 'viem';
+import { describe, expect, it } from 'vitest';
+import { toF4 } from '../../../utils/toF4';
+import { NATIVE_FILECOIN_PROVIDER_PLACEHOLDER_METADATA } from '../nativeFilecoinProvider';
+import {
+  createEvmConnectedSender,
+  createNativeFilecoinConnectedSender,
+} from '../senderModel';
+
+const EVM_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
+
+const MAINNET_F1 = newSecp256k1Address(
+  Uint8Array.from({ length: 33 }, (_, index) => index + 1),
+  CoinType.MAIN,
+).toString();
+
+const CALIBRATION_T1 = newSecp256k1Address(
+  Uint8Array.from({ length: 33 }, (_, index) => index + 40),
+  CoinType.TEST,
+).toString();
+
+const MAINNET_F2 = newActorAddress(
+  Uint8Array.from([1, 2, 3, 4]),
+  CoinType.MAIN,
+).toString();
+
+const MAINNET_F3 = newBLSAddress(
+  Uint8Array.from({ length: 48 }, (_, index) => index + 10),
+  CoinType.MAIN,
+).toString();
+
+describe('sender model', () => {
+  it('keeps the current wagmi EVM sender model on the supported FEVM path', () => {
+    const sender = createEvmConnectedSender({
+      address: EVM_ADDRESS,
+      chainId: 314,
+      isConnected: true,
+    });
+
+    expect(sender).toMatchObject({
+      kind: 'evm',
+      address: getAddress(EVM_ADDRESS),
+      chainId: 314,
+      networkKey: 'mainnet',
+      nativePrefix: 'f',
+      networkStatus: 'supported',
+      canSignBatch: true,
+    });
+    expect(sender?.provider.capabilities.oneApprovalPerBatch).toBe(true);
+  });
+
+  it('preserves EVM sender connection state while marking unsupported chains', () => {
+    const sender = createEvmConnectedSender({
+      address: EVM_ADDRESS,
+      chainId: 1,
+      isConnected: true,
+    });
+
+    expect(sender).toMatchObject({
+      kind: 'evm',
+      address: getAddress(EVM_ADDRESS),
+      chainId: 1,
+      networkStatus: 'unsupported',
+      canSignBatch: true,
+    });
+    expect(sender?.networkKey).toBeUndefined();
+    expect(sender?.nativePrefix).toBeUndefined();
+  });
+
+  it('creates mainnet f1 and Calibration t1 native sender models without converting addresses', () => {
+    const mainnet = createNativeFilecoinConnectedSender({
+      address: `  ${MAINNET_F1}  `,
+      provider: NATIVE_FILECOIN_PROVIDER_PLACEHOLDER_METADATA,
+    });
+    const calibration = createNativeFilecoinConnectedSender({
+      address: CALIBRATION_T1,
+      provider: NATIVE_FILECOIN_PROVIDER_PLACEHOLDER_METADATA,
+    });
+
+    expect(mainnet.error).toBeUndefined();
+    expect(mainnet.sender).toMatchObject({
+      kind: 'native-filecoin',
+      address: MAINNET_F1,
+      chainId: 314,
+      networkKey: 'mainnet',
+      nativePrefix: 'f',
+      networkStatus: 'supported',
+      canSignBatch: false,
+    });
+    expect(mainnet.sender?.address.startsWith('0x')).toBe(false);
+
+    expect(calibration.error).toBeUndefined();
+    expect(calibration.sender).toMatchObject({
+      kind: 'native-filecoin',
+      address: CALIBRATION_T1,
+      chainId: 314159,
+      networkKey: 'calibration',
+      nativePrefix: 't',
+      networkStatus: 'supported',
+      canSignBatch: false,
+    });
+  });
+
+  it('rejects unsupported native sender protocols and delegated EVM twins as native senders', () => {
+    const unsupportedSenders = [
+      'f01234',
+      't01234',
+      MAINNET_F2,
+      MAINNET_F3,
+      toF4('0xe764Acf02D8B7c21d2B6A8f0a96C78541e0DC3fd', 'f'),
+    ];
+
+    for (const address of unsupportedSenders) {
+      const result = createNativeFilecoinConnectedSender({
+        address,
+        provider: NATIVE_FILECOIN_PROVIDER_PLACEHOLDER_METADATA,
+      });
+
+      expect(result.sender).toBeUndefined();
+      expect(result.error).toMatch(
+        /Only f1\/t1 secp256k1 Filecoin sender addresses|f0\/t0 ID sender addresses are not supported/,
+      );
+    }
+  });
+
+  it('blocks native sender network prefix mismatches', () => {
+    const result = createNativeFilecoinConnectedSender({
+      address: MAINNET_F1,
+      provider: NATIVE_FILECOIN_PROVIDER_PLACEHOLDER_METADATA,
+      expectedNetworkKey: 'calibration',
+    });
+
+    expect(result.sender).toBeUndefined();
+    expect(result.error).toContain('does not match the current Calibration Testnet sender network');
+  });
+});

--- a/src/lib/senders/index.ts
+++ b/src/lib/senders/index.ts
@@ -1,0 +1,3 @@
+export * from './nativeFilecoinProvider';
+export * from './senderModel';
+export * from './types';

--- a/src/lib/senders/nativeFilecoinProvider.ts
+++ b/src/lib/senders/nativeFilecoinProvider.ts
@@ -1,0 +1,76 @@
+import { getBalance } from '../DataProvider';
+import type { SendFilNetworkKey } from '../networks';
+import type {
+  NativeFilecoinConnectedSender,
+  NativeFilecoinWalletProvider,
+  SenderProviderMetadata,
+} from './types';
+
+type NativeFilecoinFeatureEnv = Record<string, string | undefined>;
+
+const nativeFilecoinProviderUnavailableReason =
+  'Native Filecoin wallet signing is scaffolded, but no browser provider has been verified for production use yet.';
+
+export const NATIVE_FILECOIN_PROVIDER_PLACEHOLDER_METADATA: SenderProviderMetadata & {
+  kind: 'native-filecoin-wallet';
+} = {
+  id: 'native-filecoin-placeholder',
+  name: 'Native Filecoin wallet',
+  kind: 'native-filecoin-wallet',
+  status: 'planned',
+  unavailableReason: nativeFilecoinProviderUnavailableReason,
+  capabilities: {
+    canConnect: false,
+    canDisconnect: false,
+    canDetectNetwork: false,
+    canReadBalance: true,
+    canSignBatch: false,
+    canSubmit: false,
+    oneApprovalPerBatch: true,
+  },
+};
+
+function createUnsupportedNativeFilecoinProvider(): NativeFilecoinWalletProvider {
+  return {
+    metadata: NATIVE_FILECOIN_PROVIDER_PLACEHOLDER_METADATA,
+    async connect() {
+      throw new Error(nativeFilecoinProviderUnavailableReason);
+    },
+    async disconnect() {
+      return undefined;
+    },
+    async getAccount() {
+      return null;
+    },
+    async getBalance(account) {
+      const balance = await getBalance(account.address, account.networkKey);
+      return BigInt(balance);
+    },
+  };
+}
+
+function isNativeFilecoinSenderFeatureEnabled(
+  env: NativeFilecoinFeatureEnv = import.meta.env as unknown as NativeFilecoinFeatureEnv,
+): boolean {
+  return env.VITE_NATIVE_FILECOIN_WALLET_ENABLED === 'true';
+}
+
+export function getNativeFilecoinWalletProviders({
+  featureEnabled = isNativeFilecoinSenderFeatureEnabled(),
+}: {
+  featureEnabled?: boolean;
+} = {}): NativeFilecoinWalletProvider[] {
+  if (!featureEnabled) {
+    return [];
+  }
+
+  return [createUnsupportedNativeFilecoinProvider()];
+}
+
+export async function getNativeFilecoinSenderBalanceAttoFil(
+  sender: NativeFilecoinConnectedSender,
+  readBalance: (address: string, networkKey: SendFilNetworkKey) => Promise<string> = getBalance,
+): Promise<bigint> {
+  const balance = await readBalance(sender.address, sender.networkKey);
+  return BigInt(balance);
+}

--- a/src/lib/senders/senderModel.ts
+++ b/src/lib/senders/senderModel.ts
@@ -1,0 +1,141 @@
+import { newFromString } from '@glif/filecoin-address';
+import { getAddress, isAddress } from 'viem';
+import {
+  getNetworkConfig,
+  getSupportedNetworkByChainId,
+  type SendFilNetworkKey,
+} from '../networks';
+import type {
+  EvmConnectedSender,
+  NativeFilecoinConnectedSender,
+  SenderProviderMetadata,
+} from './types';
+
+export const WAGMI_EVM_SENDER_PROVIDER: SenderProviderMetadata = {
+  id: 'wagmi-evm',
+  name: 'EVM wallet',
+  kind: 'evm-wallet',
+  status: 'available',
+  capabilities: {
+    canConnect: true,
+    canDisconnect: true,
+    canDetectNetwork: true,
+    canReadBalance: true,
+    canSignBatch: true,
+    canSubmit: true,
+    oneApprovalPerBatch: true,
+  },
+};
+
+export interface CreateEvmConnectedSenderParams {
+  address?: string;
+  chainId?: number;
+  isConnected: boolean;
+  provider?: SenderProviderMetadata;
+}
+
+export interface NativeSenderModelResult {
+  sender?: NativeFilecoinConnectedSender;
+  error?: string;
+}
+
+export function createEvmConnectedSender({
+  address,
+  chainId,
+  isConnected,
+  provider = WAGMI_EVM_SENDER_PROVIDER,
+}: CreateEvmConnectedSenderParams): EvmConnectedSender | undefined {
+  if (!isConnected || !address) {
+    return undefined;
+  }
+
+  if (!isAddress(address)) {
+    return undefined;
+  }
+
+  const network = getSupportedNetworkByChainId(chainId);
+
+  return {
+    kind: 'evm',
+    address: getAddress(address),
+    chainId,
+    networkKey: network?.key,
+    nativePrefix: network?.nativePrefix,
+    network,
+    networkStatus: network ? 'supported' : 'unsupported',
+    canSignBatch: provider.capabilities.canSignBatch,
+    provider,
+  };
+}
+
+function getNativeSenderNetworkKey(address: string): SendFilNetworkKey | undefined {
+  if (address.startsWith('f')) {
+    return 'mainnet';
+  }
+
+  if (address.startsWith('t')) {
+    return 'calibration';
+  }
+
+  return undefined;
+}
+
+export function createNativeFilecoinConnectedSender({
+  address,
+  provider,
+  expectedNetworkKey,
+}: {
+  address: string;
+  provider: SenderProviderMetadata;
+  expectedNetworkKey?: SendFilNetworkKey;
+}): NativeSenderModelResult {
+  const trimmedAddress = address.trim();
+
+  if (/^[ft]0/.test(trimmedAddress)) {
+    return { error: 'f0/t0 ID sender addresses are not supported' };
+  }
+
+  try {
+    newFromString(trimmedAddress);
+  } catch {
+    return { error: `Invalid native Filecoin sender address "${trimmedAddress}"` };
+  }
+
+  if (!/^[ft]1/.test(trimmedAddress)) {
+    return {
+      error:
+        'Only f1/t1 secp256k1 Filecoin sender addresses are supported by the v1 native sender model.',
+    };
+  }
+
+  const networkKey = getNativeSenderNetworkKey(trimmedAddress);
+  if (!networkKey) {
+    return {
+      error: `Native Filecoin sender address "${trimmedAddress}" has an unsupported network prefix.`,
+    };
+  }
+
+  if (expectedNetworkKey && networkKey !== expectedNetworkKey) {
+    const expectedNetwork = getNetworkConfig(expectedNetworkKey);
+
+    return {
+      error: `${trimmedAddress} does not match the current ${expectedNetwork.walletLabel} sender network.`,
+    };
+  }
+
+  const network = getNetworkConfig(networkKey);
+
+  return {
+    sender: {
+      kind: 'native-filecoin',
+      address: trimmedAddress,
+      chainId: network.chainId,
+      networkKey: network.key,
+      nativePrefix: network.nativePrefix,
+      network,
+      networkStatus: 'supported',
+      canSignBatch: provider.capabilities.canSignBatch,
+      provider,
+    },
+  };
+}

--- a/src/lib/senders/types.ts
+++ b/src/lib/senders/types.ts
@@ -1,0 +1,86 @@
+import type { FilecoinMessage } from '../DataProvider/types';
+import type {
+  NetworkPrefix,
+  SendFilNetworkConfig,
+  SendFilNetworkKey,
+} from '../networks';
+import type { PreparedBatchExecution } from '../transaction/batchExecution';
+
+export type ConnectedSenderKind = 'evm' | 'native-filecoin';
+export type SenderProviderKind = 'evm-wallet' | 'native-filecoin-wallet';
+export type SenderProviderStatus = 'available' | 'disabled' | 'planned';
+
+export interface SenderProviderCapabilities {
+  canConnect: boolean;
+  canDisconnect: boolean;
+  canDetectNetwork: boolean;
+  canReadBalance: boolean;
+  canSignBatch: boolean;
+  canSubmit: boolean;
+  oneApprovalPerBatch: boolean;
+}
+
+export interface SenderProviderMetadata {
+  id: string;
+  name: string;
+  kind: SenderProviderKind;
+  status: SenderProviderStatus;
+  capabilities: SenderProviderCapabilities;
+  unavailableReason?: string;
+}
+
+export interface ConnectedSenderBase {
+  kind: ConnectedSenderKind;
+  address: string;
+  chainId?: number;
+  networkKey?: SendFilNetworkKey;
+  nativePrefix?: NetworkPrefix;
+  network?: SendFilNetworkConfig;
+  networkStatus: 'supported' | 'unsupported';
+  canSignBatch: boolean;
+  provider: SenderProviderMetadata;
+}
+
+export interface EvmConnectedSender extends ConnectedSenderBase {
+  kind: 'evm';
+  address: `0x${string}`;
+}
+
+export interface NativeFilecoinConnectedSender extends ConnectedSenderBase {
+  kind: 'native-filecoin';
+  address: string;
+  chainId: SendFilNetworkConfig['chainId'];
+  networkKey: SendFilNetworkKey;
+  nativePrefix: NetworkPrefix;
+  network: SendFilNetworkConfig;
+  networkStatus: 'supported';
+}
+
+export type ConnectedSender = EvmConnectedSender | NativeFilecoinConnectedSender;
+
+export interface NativeFilecoinAccount {
+  address: string;
+  networkKey: SendFilNetworkKey;
+  nativePrefix: NetworkPrefix;
+}
+
+export interface NativeFilecoinBatchSigningRequest {
+  sender: NativeFilecoinConnectedSender;
+  preparedBatch: PreparedBatchExecution;
+}
+
+export interface NativeFilecoinSendResult {
+  cid: string;
+}
+
+export interface NativeFilecoinWalletProvider {
+  metadata: SenderProviderMetadata & { kind: 'native-filecoin-wallet' };
+  connect: () => Promise<NativeFilecoinAccount>;
+  disconnect: () => Promise<void>;
+  getAccount: () => Promise<NativeFilecoinAccount | null>;
+  getBalance: (account: NativeFilecoinAccount) => Promise<bigint>;
+  signAndSubmitMessage?: (message: FilecoinMessage) => Promise<NativeFilecoinSendResult>;
+  signAndSubmitBatch?: (
+    request: NativeFilecoinBatchSigningRequest,
+  ) => Promise<NativeFilecoinSendResult>;
+}


### PR DESCRIPTION
## Summary

Adds the first staged foundation for native Filecoin `f1`/`t1` senders without changing the existing FEVM/wagmi send path.

- Introduces a connected sender model with explicit `evm` and `native-filecoin` kinds plus provider capability metadata.
- Keeps the live app on the existing EVM sender path by deriving the current wagmi account through the new sender model.
- Adds a conservative native Filecoin wallet provider interface and a feature-flagged unsupported placeholder, so the UI does not imply native sending is live.
- Extends Lotus/DataProvider helpers to accept an explicit network key for native sender balance reads.
- Adds focused tests for EVM behavior, native `f1`/`t1` prefix/network handling, disabled provider capability state, and network-specific balance reads.

## Not included

- No Ledger support is implemented or implied.
- No native wallet connect/sign/submit UI is wired.
- No native outer message builder for invoking the FEVM batch engine is implemented yet.
- The legacy native message builder/executor remains non-production support code.

## Validation

- `yarn test src/lib/senders/__tests__/senderModel.test.ts src/lib/senders/__tests__/nativeFilecoinProvider.test.ts src/lib/DataProvider/__tests__/DataProvider.test.ts src/__tests__/App.test.tsx src/__tests__/app.invariants.test.tsx`
- `yarn typecheck`
- `yarn lint`
- `yarn test`