### PR TITLE
[codex] Fix review modal e2e assertions

### DIFF
--- a/tests/e2e/review-flow.spec.ts
+++ b/tests/e2e/review-flow.spec.ts
@@ -26,6 +26,14 @@ async function selectAtomicMode(page: Page) {
   await page.getByTestId('error-handling-atomic').click();
 }
 
+async function expectReviewShowsPartialHandling(page: Page) {
+  const reviewDialog = page.getByRole('dialog', { name: 'Review Batch' });
+
+  await expect(reviewDialog).toBeVisible();
+  await expect(reviewDialog.getByText('Error handling')).toBeVisible();
+  await expect(reviewDialog.getByText('Partial')).toBeVisible();
+}
+
 test('manual review can proceed without duplicate acknowledgment for unique recipients', async ({
   page,
 }) => {
@@ -97,9 +105,7 @@ test('atomic mode stays blocked and review continues with partial semantics', as
 
   await page.getByTestId('review-batch-button').click();
 
-  await expect(page.getByTestId('error-mode-summary')).toContainText(
-    'Some transfers may succeed even if others fail.',
-  );
+  await expectReviewShowsPartialHandling(page);
   await expect(page.getByTestId('send-batch-button')).toBeEnabled();
 
   await page.getByTestId('send-batch-button').click();
@@ -118,9 +124,7 @@ test('atomic selection remains blocked even for an atomic-only preflight case', 
 
   await page.getByTestId('review-batch-button').click();
 
-  await expect(page.getByTestId('error-mode-summary')).toContainText(
-    'Some transfers may succeed even if others fail.',
-  );
+  await expectReviewShowsPartialHandling(page);
   await expect(page.getByTestId('atomic-preflight-error')).toHaveCount(0);
   await expect(page.getByTestId('send-batch-button')).toBeEnabled();
 });


### PR DESCRIPTION
## Summary

- Updates the atomic-mode smoke tests to assert the current compact Review Batch dialog instead of the removed `error-mode-summary` panel.
- Keeps the assertions scoped to the modal and verifies that blocked Atomic selection still reviews as Partial.

## Root Cause

PR #50 simplified the review modal and intentionally removed the old execution-semantics panel. The e2e smoke tests still expected `data-testid="error-mode-summary"`, so PR #57 failed even though the modal opened and showed `Error handling: Partial`.

## Testing

- `yarn test:e2e:smoke`
- `yarn test:unit`