### PR TITLE
[codex] Prepare native Filecoin batch messages

### DIFF
--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -340,3 +340,5 @@ estimate/execute flow, transaction builder
 
 ### Status
 `implemented`
+
+Current repo note: the live App path still estimates and submits through the EVM/wagmi `useExecuteBatch` flow. `src/lib/transaction/nativeBatchMessage.ts` can prepare the single native Filecoin `InvokeEVM` message for a native `f1`/`t1` sender from the same prepared Multicall3 batch payload, but native wallet signing/submission is not wired into the live app yet.

--- a/src/lib/transaction/__tests__/nativeBatchMessage.test.ts
+++ b/src/lib/transaction/__tests__/nativeBatchMessage.test.ts
@@ -1,0 +1,202 @@
+import {
+  CoinType,
+  newSecp256k1Address,
+} from '@glif/filecoin-address';
+import { describe, expect, it } from 'vitest';
+import { getNetworkConfig } from '../../networks';
+import { NATIVE_FILECOIN_PROVIDER_PLACEHOLDER_METADATA } from '../../senders';
+import { createNativeFilecoinConnectedSender } from '../../senders/senderModel';
+import { toF4 } from '../../../utils/toF4';
+import { prepareBatchExecution } from '../batchExecution';
+import {
+  encodeInvokeEvmParams,
+  INVOKE_EVM_METHOD_NUMBER,
+  prepareNativeBatchMessage,
+} from '../nativeBatchMessage';
+
+const EVM_RECIPIENT = '0x1234567890abcdef1234567890abcdef12345678';
+
+const MAINNET_F1 = newSecp256k1Address(
+  Uint8Array.from({ length: 33 }, (_, index) => index + 1),
+  CoinType.MAIN,
+).toString();
+
+const CALIBRATION_T1 = newSecp256k1Address(
+  Uint8Array.from({ length: 33 }, (_, index) => index + 40),
+  CoinType.TEST,
+).toString();
+
+const BASE64_ALPHABET =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+function base64ToBytes(value: string): Uint8Array {
+  const normalized = value.replace(/=+$/, '');
+  const bytes: number[] = [];
+  let buffer = 0;
+  let bitLength = 0;
+
+  for (const char of normalized) {
+    const index = BASE64_ALPHABET.indexOf(char);
+
+    if (index < 0) {
+      throw new Error(`Invalid base64 character "${char}"`);
+    }
+
+    buffer = (buffer << 6) | index;
+    bitLength += 6;
+
+    if (bitLength >= 8) {
+      bitLength -= 8;
+      bytes.push((buffer >> bitLength) & 0xff);
+    }
+  }
+
+  return Uint8Array.from(bytes);
+}
+
+function decodeCborByteString(value: string): Uint8Array {
+  const bytes = base64ToBytes(value);
+  const first = bytes[0];
+
+  if (first === undefined || (first & 0xe0) !== 0x40) {
+    throw new Error('Expected a CBOR byte string');
+  }
+
+  const additional = first & 0x1f;
+
+  if (additional < 24) {
+    return bytes.slice(1, 1 + additional);
+  }
+
+  if (additional === 24) {
+    const length = bytes[1]!;
+    return bytes.slice(2, 2 + length);
+  }
+
+  if (additional === 25) {
+    const length = (bytes[1]! << 8) | bytes[2]!;
+    return bytes.slice(3, 3 + length);
+  }
+
+  if (additional === 26) {
+    const length =
+      (bytes[1]! << 24) | (bytes[2]! << 16) | (bytes[3]! << 8) | bytes[4]!;
+    return bytes.slice(5, 5 + length);
+  }
+
+  throw new Error('Unsupported CBOR byte string length encoding');
+}
+
+function bytesToHex(bytes: Uint8Array): `0x${string}` {
+  return `0x${Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')}`;
+}
+
+function getNativeSender(address: string) {
+  const result = createNativeFilecoinConnectedSender({
+    address,
+    provider: NATIVE_FILECOIN_PROVIDER_PLACEHOLDER_METADATA,
+  });
+
+  if (!result.sender) {
+    throw new Error(result.error ?? 'Failed to create native sender');
+  }
+
+  return result.sender;
+}
+
+describe('native Filecoin batch message preparation', () => {
+  it('builds one Calibration InvokeEVM message from the existing Multicall3 batch payload', () => {
+    const network = getNetworkConfig('calibration');
+    const sender = getNativeSender(CALIBRATION_T1);
+    const recipients = [
+      { address: EVM_RECIPIENT, amount: 1 },
+      { address: toF4(EVM_RECIPIENT, 't'), amount: 2 },
+      { address: CALIBRATION_T1, amount: 3 },
+    ];
+    const preparedBatch = prepareBatchExecution(recipients, 'PARTIAL', network);
+
+    const nativePrepared = prepareNativeBatchMessage({
+      sender,
+      preparedBatch,
+      nonce: 7,
+    });
+
+    expect(nativePrepared).toMatchObject({
+      sender,
+      preparedBatch,
+      targetEvmAddress: network.multicall3Address,
+      targetFilecoinAddress: toF4(network.multicall3Address, 't'),
+      method: INVOKE_EVM_METHOD_NUMBER,
+      paramsCodec: 'cbor-bytes-base64',
+    });
+    expect(nativePrepared.message).toEqual({
+      Version: 0,
+      To: toF4(network.multicall3Address, 't'),
+      From: CALIBRATION_T1,
+      Nonce: 7,
+      Value: '6000000000000000000',
+      Method: INVOKE_EVM_METHOD_NUMBER,
+      Params: encodeInvokeEvmParams(preparedBatch.batch.data),
+      GasLimit: 0,
+      GasFeeCap: '0',
+      GasPremium: '0',
+    });
+    expect(bytesToHex(decodeCborByteString(nativePrepared.message.Params!))).toBe(
+      preparedBatch.batch.data,
+    );
+  });
+
+  it('preserves ATOMIC call semantics from the prepared FEVM batch', () => {
+    const network = getNetworkConfig('calibration');
+    const sender = getNativeSender(CALIBRATION_T1);
+    const preparedBatch = prepareBatchExecution(
+      [{ address: CALIBRATION_T1, amount: 1 }],
+      'ATOMIC',
+      network,
+    );
+
+    const nativePrepared = prepareNativeBatchMessage({
+      sender,
+      preparedBatch,
+      nonce: 0,
+      gas: {
+        gasLimit: 123,
+        gasFeeCap: '456',
+        gasPremium: '789',
+      },
+    });
+
+    expect(preparedBatch.batch.calls.every((call) => call.allowFailure === false)).toBe(true);
+    expect(bytesToHex(decodeCborByteString(nativePrepared.message.Params!))).toBe(
+      preparedBatch.batch.data,
+    );
+    expect(nativePrepared.message).toMatchObject({
+      GasLimit: 123,
+      GasFeeCap: '456',
+      GasPremium: '789',
+    });
+  });
+
+  it('rejects native sender and batch network mismatches', () => {
+    const sender = getNativeSender(MAINNET_F1);
+    const preparedBatch = prepareBatchExecution(
+      [{ address: CALIBRATION_T1, amount: 1 }],
+      'PARTIAL',
+      getNetworkConfig('calibration'),
+    );
+
+    expect(() =>
+      prepareNativeBatchMessage({
+        sender,
+        preparedBatch,
+        nonce: 0,
+      }),
+    ).toThrow('Native sender network mainnet does not match prepared batch network calibration');
+  });
+
+  it('encodes InvokeEVM calldata as a CBOR byte string in Filecoin message params', () => {
+    expect(bytesToHex(decodeCborByteString(encodeInvokeEvmParams('0x1234abcd')))).toBe(
+      '0x1234abcd',
+    );
+  });
+});

--- a/src/lib/transaction/nativeBatchMessage.ts
+++ b/src/lib/transaction/nativeBatchMessage.ts
@@ -1,0 +1,143 @@
+import type { FilecoinMessage } from '../DataProvider/types';
+import type { NativeFilecoinConnectedSender } from '../senders';
+import { toF4 } from '../../utils/toF4';
+import type { PreparedBatchExecution } from './batchExecution';
+
+// Filecoin EVM actors expose FRC42(InvokeEVM) for native -> EVM calls.
+export const INVOKE_EVM_METHOD_NUMBER = 3_844_450_837;
+
+const BASE64_ALPHABET =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+export interface NativeBatchMessageGasFields {
+  gasLimit?: number;
+  gasFeeCap?: string;
+  gasPremium?: string;
+}
+
+export interface PrepareNativeBatchMessageParams {
+  sender: NativeFilecoinConnectedSender;
+  preparedBatch: PreparedBatchExecution;
+  nonce: number;
+  gas?: NativeBatchMessageGasFields;
+}
+
+export interface PreparedNativeBatchMessage {
+  message: FilecoinMessage;
+  sender: NativeFilecoinConnectedSender;
+  preparedBatch: PreparedBatchExecution;
+  targetEvmAddress: `0x${string}`;
+  targetFilecoinAddress: string;
+  method: typeof INVOKE_EVM_METHOD_NUMBER;
+  paramsCodec: 'cbor-bytes-base64';
+}
+
+function hexToBytes(hex: `0x${string}`): Uint8Array {
+  const value = hex.slice(2);
+
+  if (value.length % 2 !== 0) {
+    throw new Error('Hex calldata must have an even number of characters');
+  }
+
+  const bytes = new Uint8Array(value.length / 2);
+
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number.parseInt(value.slice(index * 2, index * 2 + 2), 16);
+  }
+
+  return bytes;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let output = '';
+
+  for (let index = 0; index < bytes.length; index += 3) {
+    const first = bytes[index]!;
+    const second = bytes[index + 1];
+    const third = bytes[index + 2];
+    const hasSecond = second !== undefined;
+    const hasThird = third !== undefined;
+    const chunk = (first << 16) | ((second ?? 0) << 8) | (third ?? 0);
+
+    output += BASE64_ALPHABET[(chunk >> 18) & 0x3f];
+    output += BASE64_ALPHABET[(chunk >> 12) & 0x3f];
+    output += hasSecond ? BASE64_ALPHABET[(chunk >> 6) & 0x3f] : '=';
+    output += hasThird ? BASE64_ALPHABET[chunk & 0x3f] : '=';
+  }
+
+  return output;
+}
+
+function encodeCborByteString(bytes: Uint8Array): Uint8Array {
+  const length = bytes.length;
+
+  if (length < 24) {
+    return Uint8Array.from([0x40 + length, ...bytes]);
+  }
+
+  if (length <= 0xff) {
+    return Uint8Array.from([0x58, length, ...bytes]);
+  }
+
+  if (length <= 0xffff) {
+    return Uint8Array.from([0x59, (length >> 8) & 0xff, length & 0xff, ...bytes]);
+  }
+
+  if (length <= 0xffffffff) {
+    return Uint8Array.from([
+      0x5a,
+      (length >> 24) & 0xff,
+      (length >> 16) & 0xff,
+      (length >> 8) & 0xff,
+      length & 0xff,
+      ...bytes,
+    ]);
+  }
+
+  throw new Error('Calldata is too large to encode as a native Filecoin InvokeEVM param');
+}
+
+export function encodeInvokeEvmParams(calldata: `0x${string}`): string {
+  return bytesToBase64(encodeCborByteString(hexToBytes(calldata)));
+}
+
+export function prepareNativeBatchMessage({
+  sender,
+  preparedBatch,
+  nonce,
+  gas,
+}: PrepareNativeBatchMessageParams): PreparedNativeBatchMessage {
+  if (sender.networkKey !== preparedBatch.networkKey || sender.chainId !== preparedBatch.chainId) {
+    throw new Error(
+      `Native sender network ${sender.networkKey} does not match prepared batch network ${preparedBatch.networkKey}.`,
+    );
+  }
+
+  if (nonce < 0 || !Number.isInteger(nonce)) {
+    throw new Error('Native Filecoin message nonce must be a non-negative integer');
+  }
+
+  const targetFilecoinAddress = toF4(preparedBatch.batch.to, sender.nativePrefix);
+  const message: FilecoinMessage = {
+    Version: 0,
+    To: targetFilecoinAddress,
+    From: sender.address,
+    Nonce: nonce,
+    Value: preparedBatch.totalValueAttoFil.toString(),
+    Method: INVOKE_EVM_METHOD_NUMBER,
+    Params: encodeInvokeEvmParams(preparedBatch.batch.data),
+    GasLimit: gas?.gasLimit ?? 0,
+    GasFeeCap: gas?.gasFeeCap ?? '0',
+    GasPremium: gas?.gasPremium ?? '0',
+  };
+
+  return {
+    message,
+    sender,
+    preparedBatch,
+    targetEvmAddress: preparedBatch.batch.to,
+    targetFilecoinAddress,
+    method: INVOKE_EVM_METHOD_NUMBER,
+    paramsCodec: 'cbor-bytes-base64',
+  };
+}


### PR DESCRIPTION
## Summary

Adds the next staged native Filecoin sender foundation: preparing the single native Filecoin message that will eventually be signed by an `f1`/`t1` wallet.

- Adds `nativeBatchMessage.ts` to convert an existing prepared Multicall3 batch into one native Filecoin `InvokeEVM` message.
- Targets Multicall3 through its `f4`/`t4` delegated address while preserving the existing FEVM calldata and total value.
- Encodes `aggregate3Value` calldata as CBOR byte-string Filecoin message params for `FRC42(InvokeEVM)` method `3844450837`.
- Rejects native sender / prepared batch network mismatches.
- Adds focused tests for Calibration message preparation, ATOMIC semantics preservation, CBOR params round-tripping, and network mismatch blocking.
- Updates invariants docs to make clear this is preparation-only and native wallet signing/submission is not live.

## Not included

- No native wallet connect, sign, or submit flow is wired.
- No Ledger support is implemented or implied.
- No native gas estimation is wired into the review UI.
- The live App path continues to use the EVM/wagmi `useExecuteBatch` flow.

## Validation

- `yarn test src/lib/transaction/__tests__/nativeBatchMessage.test.ts src/lib/transaction/__tests__/batchExecution.test.ts src/lib/senders/__tests__/senderModel.test.ts src/lib/senders/__tests__/nativeFilecoinProvider.test.ts`
- `yarn typecheck`
- `yarn lint`
- `yarn test`