### PR TITLE
[codex] Add native Filecoin batch preflight

### DIFF
--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -28,7 +28,7 @@ Use this catalog before changing validation, network gating, review/send flow, R
 | `INV-NET-001` | Wrong network disables Send | `implemented` | network/wallet gating, review UI gating | `src/__tests__/app.invariants.test.tsx` |
 | `INV-BAL-001` | Submit-time balance recheck blocks EVM sends when current balance is insufficient | `implemented` | submit guard, wallet RPC | `src/lib/transaction/__tests__/submitBalanceCheck.test.ts`, `src/lib/transaction/__tests__/useExecuteBatch.submitBalance.test.tsx` |
 | `INV-RPC-001` | Contract recipients detected via `eth_getCode` are blocked | `not implemented` | RPC contract-recipient check, review UI gating | `src/__tests__/contractRecipientGuard.future.test.tsx` |
-| `INV-EXEC-001` | Review estimate and submission use the same execution config | `implemented` | estimate/execute flow, transaction builder | `src/lib/transaction/__tests__/batchExecution.test.ts`, `src/__tests__/app.invariants.test.tsx` |
+| `INV-EXEC-001` | Review estimate and submission use the same execution config | `implemented` | estimate/execute flow, transaction builder | `src/lib/transaction/__tests__/batchExecution.test.ts`, `src/lib/transaction/__tests__/nativeBatchPreflight.test.ts`, `src/__tests__/app.invariants.test.tsx` |
 
 ## INV-ADDR-001 — Accept valid `f1/f2/f3/f4/0x` recipients
 
@@ -334,6 +334,9 @@ estimate/execute flow, transaction builder
 - `src/lib/transaction/__tests__/batchExecution.test.ts`
   - `describe('INV-EXEC-001 prepared batch determinism', ...)`
   - `it('produces the same prepared execution config for estimate and submit inputs')`
+- `src/lib/transaction/__tests__/nativeBatchPreflight.test.ts`
+  - `describe('native Filecoin batch preflight', ...)`
+  - `it('preserves the existing Multicall3 payload and ATOMIC call semantics')`
 - `src/__tests__/app.invariants.test.tsx`
   - `describe('INV-EXEC-001 review and submit alignment', ...)`
   - `it('passes the same execution config to estimate and execute in the live app flow')`
@@ -341,4 +344,4 @@ estimate/execute flow, transaction builder
 ### Status
 `implemented`
 
-Current repo note: the live App path still estimates and submits through the EVM/wagmi `useExecuteBatch` flow. `src/lib/transaction/nativeBatchMessage.ts` can prepare the single native Filecoin `InvokeEVM` message for a native `f1`/`t1` sender from the same prepared Multicall3 batch payload, but native wallet signing/submission is not wired into the live app yet.
+Current repo note: the live App path still estimates and submits through the EVM/wagmi `useExecuteBatch` flow. `src/lib/transaction/nativeBatchMessage.ts` can prepare the single native Filecoin `InvokeEVM` message for a native `f1`/`t1` sender from the same prepared Multicall3 batch payload, and `src/lib/transaction/nativeBatchPreflight.ts` can fetch the native nonce and Lotus gas estimate for that message. Native wallet signing/submission and review UI routing are not wired into the live app yet.

--- a/src/lib/transaction/__tests__/nativeBatchPreflight.test.ts
+++ b/src/lib/transaction/__tests__/nativeBatchPreflight.test.ts
@@ -1,0 +1,221 @@
+import {
+  CoinType,
+  newSecp256k1Address,
+} from '@glif/filecoin-address';
+import { describe, expect, it, vi } from 'vitest';
+import { getNetworkConfig, type SendFilNetworkKey } from '../../networks';
+import { NATIVE_FILECOIN_PROVIDER_PLACEHOLDER_METADATA } from '../../senders';
+import { createNativeFilecoinConnectedSender } from '../../senders/senderModel';
+import type { FilecoinMessage } from '../../DataProvider/types';
+import { toF4 } from '../../../utils/toF4';
+import { prepareBatchExecution } from '../batchExecution';
+import { encodeInvokeEvmParams, INVOKE_EVM_METHOD_NUMBER } from '../nativeBatchMessage';
+import { preflightNativeBatch, type NativeBatchPreflightRpc } from '../nativeBatchPreflight';
+
+const EVM_RECIPIENT = '0x1234567890abcdef1234567890abcdef12345678';
+
+const MAINNET_F1 = newSecp256k1Address(
+  Uint8Array.from({ length: 33 }, (_, index) => index + 1),
+  CoinType.MAIN,
+).toString();
+
+const CALIBRATION_T1 = newSecp256k1Address(
+  Uint8Array.from({ length: 33 }, (_, index) => index + 40),
+  CoinType.TEST,
+).toString();
+
+function getNativeSender(address: string) {
+  const result = createNativeFilecoinConnectedSender({
+    address,
+    provider: NATIVE_FILECOIN_PROVIDER_PLACEHOLDER_METADATA,
+  });
+
+  if (!result.sender) {
+    throw new Error(result.error ?? 'Failed to create native sender');
+  }
+
+  return result.sender;
+}
+
+function getRpc(gasFields?: Partial<Pick<FilecoinMessage, 'GasLimit' | 'GasFeeCap' | 'GasPremium'>>) {
+  return {
+    getNonce: vi.fn(async (address: string, networkKey: SendFilNetworkKey) => {
+      void address;
+      void networkKey;
+
+      return 9;
+    }),
+    estimateGas: vi.fn(async (message: FilecoinMessage, networkKey: SendFilNetworkKey) => {
+      void networkKey;
+
+      return {
+        ...message,
+        GasLimit: gasFields?.GasLimit ?? 12_345,
+        GasFeeCap: gasFields?.GasFeeCap ?? '456',
+        GasPremium: gasFields?.GasPremium ?? '7',
+      };
+    }),
+  } satisfies Required<NativeBatchPreflightRpc>;
+}
+
+describe('native Filecoin batch preflight', () => {
+  it('preflights a Calibration native sender as one InvokeEVM message using Calibration RPC calls', async () => {
+    const network = getNetworkConfig('calibration');
+    const sender = getNativeSender(CALIBRATION_T1);
+    const rpc = getRpc();
+    const recipients = [
+      { address: EVM_RECIPIENT, amount: 1 },
+      { address: toF4(EVM_RECIPIENT, 't'), amount: 2 },
+      { address: CALIBRATION_T1, amount: 3 },
+    ];
+
+    const result = await preflightNativeBatch({
+      sender,
+      recipients,
+      errorMode: 'PARTIAL',
+      network,
+      rpc,
+    });
+
+    expect(rpc.getNonce).toHaveBeenCalledWith(CALIBRATION_T1, 'calibration');
+    expect(rpc.estimateGas).toHaveBeenCalledTimes(1);
+    const [draftMessage, rpcNetworkKey] = rpc.estimateGas.mock.calls[0]!;
+
+    expect(rpcNetworkKey).toBe('calibration');
+    expect(draftMessage).toEqual(result.draftNativeMessage.message);
+    expect(draftMessage).toMatchObject({
+      Version: 0,
+      To: toF4(network.multicall3Address, 't'),
+      From: CALIBRATION_T1,
+      Nonce: 9,
+      Value: '6000000000000000000',
+      Method: INVOKE_EVM_METHOD_NUMBER,
+      Params: encodeInvokeEvmParams(result.preparedBatch.batch.data),
+      GasLimit: 0,
+      GasFeeCap: '0',
+      GasPremium: '0',
+    });
+    expect(result.estimatedNativeMessage.message).toMatchObject({
+      To: toF4(network.multicall3Address, 't'),
+      GasLimit: 12_345,
+      GasFeeCap: '456',
+      GasPremium: '7',
+    });
+    expect(result.gasEstimate).toEqual({
+      gasLimit: 12_345n,
+      gasFeeCap: 456n,
+      gasPremium: 7n,
+      estimatedFee: 12_345n * 456n,
+    });
+  });
+
+  it('uses mainnet sender and RPC network keys for f1 native senders', async () => {
+    const network = getNetworkConfig('mainnet');
+    const sender = getNativeSender(MAINNET_F1);
+    const rpc = getRpc({
+      GasLimit: 20_000,
+      GasFeeCap: '300',
+      GasPremium: '2',
+    });
+
+    const result = await preflightNativeBatch({
+      sender,
+      recipients: [{ address: MAINNET_F1, amount: 0.5 }],
+      errorMode: 'PARTIAL',
+      network,
+      rpc,
+    });
+
+    expect(rpc.getNonce).toHaveBeenCalledWith(MAINNET_F1, 'mainnet');
+    expect(rpc.estimateGas).toHaveBeenCalledWith(
+      result.draftNativeMessage.message,
+      'mainnet',
+    );
+    expect(result.estimatedNativeMessage).toMatchObject({
+      targetFilecoinAddress: toF4(network.multicall3Address, 'f'),
+      targetEvmAddress: network.multicall3Address,
+    });
+    expect(result.gasEstimate).toEqual({
+      gasLimit: 20_000n,
+      gasFeeCap: 300n,
+      gasPremium: 2n,
+      estimatedFee: 20_000n * 300n,
+    });
+  });
+
+  it('blocks native sender and batch network mismatches before RPC calls', async () => {
+    const sender = getNativeSender(MAINNET_F1);
+    const rpc = getRpc();
+
+    await expect(
+      preflightNativeBatch({
+        sender,
+        recipients: [{ address: CALIBRATION_T1, amount: 1 }],
+        errorMode: 'PARTIAL',
+        network: getNetworkConfig('calibration'),
+        rpc,
+      }),
+    ).rejects.toThrow(
+      'Native sender network mainnet does not match requested batch network calibration',
+    );
+
+    expect(rpc.getNonce).not.toHaveBeenCalled();
+    expect(rpc.estimateGas).not.toHaveBeenCalled();
+  });
+
+  it('preserves the existing Multicall3 payload and ATOMIC call semantics', async () => {
+    const network = getNetworkConfig('calibration');
+    const sender = getNativeSender(CALIBRATION_T1);
+    const rpc = getRpc();
+    const recipients = [
+      { address: EVM_RECIPIENT, amount: 1 },
+      { address: CALIBRATION_T1, amount: 2 },
+    ];
+    const expectedPreparedBatch = prepareBatchExecution(recipients, 'ATOMIC', network);
+
+    const result = await preflightNativeBatch({
+      sender,
+      recipients,
+      errorMode: 'ATOMIC',
+      network,
+      rpc,
+    });
+
+    expect(result.preparedBatch.batch.data).toBe(expectedPreparedBatch.batch.data);
+    expect(result.preparedBatch.batch.calls.every((call) => call.allowFailure === false)).toBe(
+      true,
+    );
+    expect(result.estimatedNativeMessage.message.Params).toBe(
+      encodeInvokeEvmParams(expectedPreparedBatch.batch.data),
+    );
+  });
+
+  it('propagates native gas estimation failures without creating a submit-ready message', async () => {
+    const network = getNetworkConfig('calibration');
+    const sender = getNativeSender(CALIBRATION_T1);
+    const rpc = {
+      getNonce: vi.fn(async (address: string, networkKey: SendFilNetworkKey) => {
+        void address;
+        void networkKey;
+
+        return 1;
+      }),
+      estimateGas: vi.fn(async (message: FilecoinMessage, networkKey: SendFilNetworkKey) => {
+        void message;
+        void networkKey;
+
+        throw new Error('Calibration Lotus gas estimation failed');
+      }),
+    } satisfies Required<NativeBatchPreflightRpc>;
+
+    await expect(
+      preflightNativeBatch({
+        sender,
+        recipients: [{ address: CALIBRATION_T1, amount: 1 }],
+        errorMode: 'PARTIAL',
+        network,
+        rpc,
+      }),
+    ).rejects.toThrow('Calibration Lotus gas estimation failed');
+  });
+});

--- a/src/lib/transaction/nativeBatchPreflight.ts
+++ b/src/lib/transaction/nativeBatchPreflight.ts
@@ -1,0 +1,125 @@
+import {
+  estimateGas as estimateLotusGas,
+  getNonce as getNativeNonce,
+} from '../DataProvider';
+import type { FilecoinMessage } from '../DataProvider/types';
+import type {
+  SendFilNetworkConfig,
+  SendFilNetworkKey,
+} from '../networks';
+import type { NativeFilecoinConnectedSender } from '../senders';
+import {
+  prepareBatchExecution,
+  type BatchExecutionRecipient,
+  type BatchGasEstimate,
+  type PreparedBatchExecution,
+} from './batchExecution';
+import type { ErrorMode } from './multicall';
+import {
+  prepareNativeBatchMessage,
+  type PreparedNativeBatchMessage,
+} from './nativeBatchMessage';
+
+export type NativeBatchPreflightNetwork = Pick<
+  SendFilNetworkConfig,
+  'key' | 'chainId' | 'multicall3Address' | 'filForwarderAddress'
+>;
+
+export interface NativeBatchPreflightRpc {
+  getNonce?: (
+    address: string,
+    networkKey: SendFilNetworkKey,
+  ) => Promise<number>;
+  estimateGas?: (
+    message: FilecoinMessage,
+    networkKey: SendFilNetworkKey,
+  ) => Promise<FilecoinMessage>;
+}
+
+export interface NativeBatchPreflightRequest {
+  sender: NativeFilecoinConnectedSender;
+  recipients: BatchExecutionRecipient[];
+  errorMode: ErrorMode;
+  network: NativeBatchPreflightNetwork;
+  rpc?: NativeBatchPreflightRpc;
+}
+
+export interface PreparedNativeBatchPreflight {
+  sender: NativeFilecoinConnectedSender;
+  preparedBatch: PreparedBatchExecution;
+  nonce: number;
+  draftNativeMessage: PreparedNativeBatchMessage;
+  estimatedNativeMessage: PreparedNativeBatchMessage;
+  gasEstimate: BatchGasEstimate;
+}
+
+function buildNativeBatchGasEstimate(message: FilecoinMessage): BatchGasEstimate {
+  const gasLimit = BigInt(message.GasLimit);
+  const gasFeeCap = BigInt(message.GasFeeCap);
+  const gasPremium = BigInt(message.GasPremium);
+
+  return {
+    gasLimit,
+    gasFeeCap,
+    gasPremium,
+    estimatedFee: gasLimit * gasFeeCap,
+  };
+}
+
+function assertNativeSenderMatchesNetwork(
+  sender: NativeFilecoinConnectedSender,
+  network: NativeBatchPreflightNetwork,
+): void {
+  if (sender.networkKey !== network.key || sender.chainId !== network.chainId) {
+    throw new Error(
+      `Native sender network ${sender.networkKey} does not match requested batch network ${network.key}.`,
+    );
+  }
+}
+
+export async function preflightNativeBatch({
+  sender,
+  recipients,
+  errorMode,
+  network,
+  rpc,
+}: NativeBatchPreflightRequest): Promise<PreparedNativeBatchPreflight> {
+  assertNativeSenderMatchesNetwork(sender, network);
+
+  const readNonce = rpc?.getNonce ?? getNativeNonce;
+  const estimateGas =
+    rpc?.estimateGas ??
+    ((message: FilecoinMessage, networkKey: SendFilNetworkKey) =>
+      estimateLotusGas(message, undefined, networkKey));
+
+  const preparedBatch = prepareBatchExecution(recipients, errorMode, network);
+  const nonce = await readNonce(sender.address, sender.networkKey);
+  const draftNativeMessage = prepareNativeBatchMessage({
+    sender,
+    preparedBatch,
+    nonce,
+  });
+  const estimatedMessage = await estimateGas(
+    draftNativeMessage.message,
+    sender.networkKey,
+  );
+  const estimatedNativeMessage = prepareNativeBatchMessage({
+    sender,
+    preparedBatch,
+    nonce,
+    gas: {
+      gasLimit: estimatedMessage.GasLimit,
+      gasFeeCap: estimatedMessage.GasFeeCap,
+      gasPremium: estimatedMessage.GasPremium,
+    },
+  });
+
+  return {
+    sender,
+    preparedBatch,
+    nonce,
+    draftNativeMessage,
+    estimatedNativeMessage,
+    gasEstimate: buildNativeBatchGasEstimate(estimatedNativeMessage.message),
+  };
+}


### PR DESCRIPTION
## Summary

Adds the next safe foundation piece for native Filecoin `f1`/`t1` sender support: a native batch preflight helper that prepares the existing FEVM Multicall3 batch, builds the native `InvokeEVM` Filecoin message, fetches the native nonce, and applies Lotus gas estimates.

This intentionally does not wire native wallet connection, signing, submission, Ledger, or review UI routing into the live app path. The live FEVM/wagmi send flow remains unchanged.

## What changed

- Added `preflightNativeBatch(...)` for native sender batch preparation and gas preflight.
- Enforced native sender network matches requested batch network before nonce or gas RPC calls.
- Added tests for Calibration `t1`, mainnet `f1`, network mismatch blocking, ATOMIC payload preservation, and gas estimation failure propagation.
- Updated invariants docs to distinguish native message/preflight scaffolding from live native wallet support.

## Validation

- `yarn test src/lib/transaction/__tests__/nativeBatchPreflight.test.ts src/lib/transaction/__tests__/nativeBatchMessage.test.ts src/lib/transaction/__tests__/batchExecution.test.ts src/lib/senders/__tests__/senderModel.test.ts`
- `yarn lint`
- `yarn typecheck`
- `yarn test`
- `yarn build`

`yarn build` still emits the existing Vite large chunk warning.