### PR TITLE
[codex] Add live connected sender adapter

### DIFF
--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -25,7 +25,7 @@ Use this catalog before changing validation, network gating, review/send flow, R
 | `INV-AMT-002` | Reject values with more than 18 decimal places | `implemented` | validation, amount parsing | `src/utils/__tests__/recipientValidation.test.ts` |
 | `INV-BATCH-001` | Enforce the 500-recipient cap | `implemented` | validation | `src/utils/__tests__/recipientValidation.test.ts` |
 | `INV-DUP-001` | Duplicate recipients require explicit confirmation before Send | `implemented` | duplicate detection, review UI gating | `src/utils/__tests__/recipientValidation.test.ts`, `src/components/__tests__/ReviewTransactionModal.test.tsx`, `tests/e2e/review-flow.spec.ts` |
-| `INV-NET-001` | Wrong network disables Send | `implemented` | network/wallet gating, review UI gating | `src/__tests__/app.invariants.test.tsx` |
+| `INV-NET-001` | Wrong network disables Send | `implemented` | network/wallet gating, review UI gating | `src/lib/senders/__tests__/connectedSender.test.ts`, `src/__tests__/app.invariants.test.tsx` |
 | `INV-BAL-001` | Submit-time balance recheck blocks EVM sends when current balance is insufficient | `implemented` | submit guard, wallet RPC | `src/lib/transaction/__tests__/submitBalanceCheck.test.ts`, `src/lib/transaction/__tests__/useExecuteBatch.submitBalance.test.tsx` |
 | `INV-RPC-001` | Contract recipients detected via `eth_getCode` are blocked | `not implemented` | RPC contract-recipient check, review UI gating | `src/__tests__/contractRecipientGuard.future.test.tsx` |
 | `INV-EXEC-001` | Review estimate and submission use the same execution config | `implemented` | estimate/execute flow, transaction builder | `src/lib/transaction/__tests__/batchExecution.test.ts`, `src/lib/transaction/__tests__/nativeBatchPreflight.test.ts`, `src/__tests__/app.invariants.test.tsx` |
@@ -245,11 +245,15 @@ network/wallet gating, review UI gating
 - `src/__tests__/app.invariants.test.tsx`
   - `describe('INV-NET-001 wrong network gating', ...)`
   - `it('blocks review and send while the wallet is connected to an unsupported chain')`
+- `src/lib/senders/__tests__/connectedSender.test.ts`
+  - `describe('connected sender state', ...)`
+  - `it('keeps unsupported EVM networks connected but disables network-scoped reads')`
+  - `it('models native f1/t1 senders as unsupported by the live send path until signing is wired')`
 
 ### Status
 `implemented`
 
-Current repo note: the live block happens at the App review boundary, not by a wallet-driven switch action inside the review modal.
+Current repo note: the live block happens at the App review boundary, not by a wallet-driven switch action inside the review modal. `src/lib/senders/useConnectedSender.ts` now centralizes the live connected-sender state for the App. It exposes the current EVM/wagmi sender as the only live send-capable path and keeps native Filecoin sender models/provider placeholders from enabling review or send until native wallet signing is actually wired.
 
 ## INV-BAL-001 — Submit-Time Balance Recheck
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import ReviewTransactionModal, {
   GasEstimate,
 } from './components/ReviewTransactionModal';
 import UnavailableCapabilityModal from './components/UnavailableCapabilityModal';
-import { useAccount, useBalance, useChainId } from 'wagmi';
+import { useBalance } from 'wagmi';
 import { formatUnits } from 'viem';
 import { calculateFeeRows, getFeeLabel } from './utils/fee';
 import {
@@ -36,7 +36,7 @@ import {
   getSupportedNetworkByChainId,
   getSupportedNetworkListLabel,
 } from './lib/networks';
-import { createEvmConnectedSender } from './lib/senders';
+import { useConnectedSender } from './lib/senders';
 
 interface Recipient {
   address: string;
@@ -312,34 +312,39 @@ function ConfigurationChoiceGroup({
 }
 
 export default function App() {
-  const account = useAccount();
-  const walletChainId = useChainId();
-  const connectedSender = React.useMemo(
-    () =>
-      createEvmConnectedSender({
-        address: E2E_MOCK_WALLET_ENABLED ? E2E_MOCK_ACCOUNT : account.address,
-        chainId: E2E_MOCK_WALLET_ENABLED ? E2E_MOCK_CHAIN_ID : walletChainId,
-        isConnected: E2E_MOCK_WALLET_ENABLED ? true : account.isConnected,
-      }),
-    [account.address, account.isConnected, walletChainId],
+  const e2eMockWallet = React.useMemo(
+    () => ({
+      enabled: E2E_MOCK_WALLET_ENABLED,
+      address: E2E_MOCK_ACCOUNT,
+      chainId: E2E_MOCK_CHAIN_ID,
+    }),
+    [],
   );
-  const isConnected = Boolean(connectedSender);
-  const address = connectedSender?.address;
-  const chainId = connectedSender?.chainId;
-  const connectedNetwork = connectedSender?.network;
-  const hasSupportedConnectedNetwork =
-    isConnected && connectedSender?.networkStatus === 'supported';
-  const isUnsupportedConnectedNetwork =
-    isConnected && connectedSender?.networkStatus === 'unsupported';
-  const expectedNetworkPrefix = connectedNetwork?.nativePrefix;
+  const connectedSenderState = useConnectedSender({
+    e2eMockWallet,
+  });
+  const {
+    connectedSender,
+    isConnected,
+    address,
+    chainId,
+    connectedNetwork,
+    hasSupportedConnectedNetwork,
+    isUnsupportedConnectedNetwork,
+    expectedNetworkPrefix,
+    balanceSource,
+    canUseLiveSendPath,
+    liveSendPathUnavailableReason,
+  } = connectedSenderState;
   const feeLabel = getFeeLabel(connectedNetwork?.chainId);
+  const evmBalanceSource =
+    balanceSource.kind === 'evm-wagmi' ? balanceSource : undefined;
   const { data: balanceData } = useBalance({
-    address: connectedSender?.kind === 'evm' ? connectedSender.address : undefined,
-    chainId: connectedNetwork?.chainId,
+    address: evmBalanceSource?.address,
+    chainId: evmBalanceSource?.chainId,
     query: {
       enabled: Boolean(
-        connectedSender?.kind === 'evm' &&
-          connectedSender.address &&
+        evmBalanceSource?.enabled &&
           hasSupportedConnectedNetwork &&
           !E2E_MOCK_WALLET_ENABLED,
       ),
@@ -660,7 +665,8 @@ export default function App() {
     [manualRecipients],
   );
 
-  const reviewDisabled = !isConnected || isNetworkMismatch || !hasReviewableRows;
+  const reviewDisabled =
+    !isConnected || !canUseLiveSendPath || isNetworkMismatch || !hasReviewableRows;
   const transactionState: TransactionState =
     executionState === 'idle'
       ? 'review'
@@ -675,6 +681,10 @@ export default function App() {
 
     if (isNetworkMismatch) {
       return `Switch to ${getSupportedNetworkListLabel()} before continuing.`;
+    }
+
+    if (!canUseLiveSendPath) {
+      return liveSendPathUnavailableReason ?? 'The connected sender cannot review or send yet.';
     }
 
     if (!hasReviewableRows) {
@@ -701,13 +711,21 @@ export default function App() {
     activeValidationWarnings.length,
     hasReviewableRows,
     inputMode,
+    canUseLiveSendPath,
     isConnected,
     isNetworkMismatch,
+    liveSendPathUnavailableReason,
     manualIncompleteRowCount,
   ]);
 
   const handleReview = async () => {
-    if (!isConnected || !address || isNetworkMismatch || !hasReviewableRows) {
+    if (
+      !isConnected ||
+      !canUseLiveSendPath ||
+      !address ||
+      isNetworkMismatch ||
+      !hasReviewableRows
+    ) {
       return;
     }
 
@@ -789,6 +807,7 @@ export default function App() {
   const handleConfirmTransaction = async () => {
     if (
       !isConnected ||
+      !canUseLiveSendPath ||
       !address ||
       isNetworkMismatch ||
       activeBlockingValidationErrors.length > 0
@@ -930,7 +949,7 @@ f1cj...,3.3`;
               </p>
             </header>
 
-            <NetworkBanner />
+            <NetworkBanner connectedSender={connectedSender} />
 
             <div className="mb-6 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
               <div className="inline-flex rounded-full border border-slate-200 bg-white p-1 shadow-sm">
@@ -1340,6 +1359,8 @@ f1cj...,3.3`;
                       ? 'Connect Wallet to Review'
                       : isNetworkMismatch
                         ? 'Switch Network to Review'
+                        : !canUseLiveSendPath
+                          ? 'Sender Not Available'
                         : `Review Batch${draftRecipientCount > 0 ? ` (${draftRecipientCount})` : ''}`}
                   </button>
                 </div>

--- a/src/components/CustomConnectButton.tsx
+++ b/src/components/CustomConnectButton.tsx
@@ -6,9 +6,10 @@ import {
   getSupportedNetworkListLabel,
 } from '../lib/networks';
 import {
-  convertEthToDelegatedAddress,
-  truncateAddress,
-} from '../utils/addressConverter';
+  createEvmConnectedSender,
+  getSenderDisplayAddress,
+} from '../lib/senders';
+import { truncateAddress } from '../utils/addressConverter';
 
 const E2E_MOCK_WALLET_ENABLED = import.meta.env.VITE_E2E_MOCK_WALLET === 'true';
 
@@ -64,10 +65,17 @@ export const CustomConnectButton: React.FC = () => {
           chain &&
           (!authenticationStatus || authenticationStatus === 'authenticated');
         const supportedNetwork = chain ? getSupportedNetworkByChainId(chain.id) : undefined;
-        const delegatedAddress =
+        const connectedSender =
           account && supportedNetwork
-            ? convertEthToDelegatedAddress(account.address, supportedNetwork.chainId)
-            : account?.address;
+            ? createEvmConnectedSender({
+                address: account.address,
+                chainId: supportedNetwork.chainId,
+                isConnected: true,
+              })
+            : undefined;
+        const senderDisplayAddress = connectedSender
+          ? getSenderDisplayAddress(connectedSender)
+          : account?.address;
         const networkLabel = supportedNetwork?.walletLabel ?? chain?.name;
 
         const renderDisconnectedState = () => (
@@ -85,7 +93,7 @@ export const CustomConnectButton: React.FC = () => {
             return null;
           }
 
-          const displayAddress = truncateAddress(delegatedAddress ?? account.address, 5);
+          const displayAddress = truncateAddress(senderDisplayAddress ?? account.address, 5);
           const isWrongNetwork = chain.unsupported || !supportedNetwork;
 
           return (
@@ -118,7 +126,7 @@ export const CustomConnectButton: React.FC = () => {
                 type="button"
                 onClick={() => setShowAccountModal(true)}
                 className={`w-full rounded-full bg-[#4a84ea] px-4 py-4 text-left text-white transition-colors hover:bg-[#3f77dd] ${primaryActionShadow}`}
-                title={delegatedAddress}
+                title={senderDisplayAddress}
               >
                 <div className="font-mono text-base font-semibold">{displayAddress}</div>
                 <div className="mt-1 text-sm text-blue-100">{account.displayBalance || '0 FIL'}</div>
@@ -159,7 +167,7 @@ export const CustomConnectButton: React.FC = () => {
                     </div>
 
                     <h3 className="font-mono text-base font-semibold text-slate-950">
-                      {delegatedAddress ?? account.address}
+                      {senderDisplayAddress ?? account.address}
                     </h3>
                     <p className="mt-2 text-sm text-slate-500">{networkLabel}</p>
                     <p className="mt-2 text-sm text-slate-500">
@@ -170,7 +178,7 @@ export const CustomConnectButton: React.FC = () => {
                       <button
                         type="button"
                         onClick={() => {
-                          copyToClipboard(delegatedAddress ?? account.address);
+                          copyToClipboard(senderDisplayAddress ?? account.address);
                           setShowAccountModal(false);
                         }}
                         className="flex-1 rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm font-medium text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-100"

--- a/src/components/NetworkBanner.tsx
+++ b/src/components/NetworkBanner.tsx
@@ -4,11 +4,19 @@ import {
   getSupportedNetworkByChainId,
   getSupportedNetworkListLabel,
 } from '../lib/networks';
+import type { ConnectedSender } from '../lib/senders';
 
-const NetworkBanner: React.FC = () => {
-  const chainId = useChainId();
-  const { isConnected } = useAccount();
-  const network = getSupportedNetworkByChainId(chainId);
+interface NetworkBannerProps {
+  connectedSender?: ConnectedSender;
+}
+
+const NetworkBanner: React.FC<NetworkBannerProps> = ({ connectedSender }) => {
+  const wagmiChainId = useChainId();
+  const { isConnected: isWagmiConnected } = useAccount();
+  const chainId = connectedSender?.chainId ?? wagmiChainId;
+  const isConnected = Boolean(connectedSender) || isWagmiConnected;
+  const network =
+    connectedSender?.network ?? getSupportedNetworkByChainId(chainId);
 
   if (!isConnected || !chainId) return null;
   if (!network) {

--- a/src/lib/senders/__tests__/connectedSender.test.ts
+++ b/src/lib/senders/__tests__/connectedSender.test.ts
@@ -1,0 +1,245 @@
+import {
+  CoinType,
+  newSecp256k1Address,
+} from '@glif/filecoin-address';
+import { getAddress } from 'viem';
+import { describe, expect, it } from 'vitest';
+import { toF4 } from '../../../utils/toF4';
+import { NATIVE_FILECOIN_PROVIDER_PLACEHOLDER_METADATA } from '../nativeFilecoinProvider';
+import {
+  getSenderDisplayAddress,
+  resolveConnectedSenderState,
+} from '../connectedSender';
+import { createNativeFilecoinConnectedSender } from '../senderModel';
+import type { NativeFilecoinWalletProvider } from '../types';
+
+const EVM_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
+
+const MAINNET_F1 = newSecp256k1Address(
+  Uint8Array.from({ length: 33 }, (_, index) => index + 1),
+  CoinType.MAIN,
+).toString();
+
+const CALIBRATION_T1 = newSecp256k1Address(
+  Uint8Array.from({ length: 33 }, (_, index) => index + 40),
+  CoinType.TEST,
+).toString();
+
+function getNativeSender(address: string) {
+  const result = createNativeFilecoinConnectedSender({
+    address,
+    provider: NATIVE_FILECOIN_PROVIDER_PLACEHOLDER_METADATA,
+  });
+
+  if (!result.sender) {
+    throw new Error(result.error ?? 'Failed to create native sender');
+  }
+
+  return result.sender;
+}
+
+function getPlannedNativeProvider(): NativeFilecoinWalletProvider {
+  return {
+    metadata: NATIVE_FILECOIN_PROVIDER_PLACEHOLDER_METADATA,
+    async connect() {
+      throw new Error('Native provider is planned');
+    },
+    async disconnect() {
+      return undefined;
+    },
+    async getAccount() {
+      return null;
+    },
+    async getBalance() {
+      return 0n;
+    },
+  };
+}
+
+describe('connected sender state', () => {
+  it('resolves the existing wagmi EVM sender as the only live send-capable path', () => {
+    const state = resolveConnectedSenderState({
+      evmWallet: {
+        address: EVM_ADDRESS,
+        chainId: 314,
+        isConnected: true,
+      },
+    });
+
+    expect(state.connectedSender).toMatchObject({
+      kind: 'evm',
+      address: getAddress(EVM_ADDRESS),
+      chainId: 314,
+      networkKey: 'mainnet',
+      networkStatus: 'supported',
+      canSignBatch: true,
+    });
+    expect(state.canUseLiveSendPath).toBe(true);
+    expect(state.expectedNetworkPrefix).toBe('f');
+    expect(state.balanceSource).toEqual({
+      kind: 'evm-wagmi',
+      enabled: true,
+      address: getAddress(EVM_ADDRESS),
+      chainId: 314,
+    });
+  });
+
+  it('keeps unsupported EVM networks connected but disables network-scoped reads', () => {
+    const state = resolveConnectedSenderState({
+      evmWallet: {
+        address: EVM_ADDRESS,
+        chainId: 1,
+        isConnected: true,
+      },
+    });
+
+    expect(state.isConnected).toBe(true);
+    expect(state.isUnsupportedConnectedNetwork).toBe(true);
+    expect(state.hasSupportedConnectedNetwork).toBe(false);
+    expect(state.canUseLiveSendPath).toBe(false);
+    expect(state.connectedNetwork).toBeUndefined();
+    expect(state.balanceSource).toEqual({
+      kind: 'none',
+      enabled: false,
+      reason: 'unsupported-network',
+    });
+  });
+
+  it('uses the E2E mock wallet snapshot without changing the production EVM model', () => {
+    const state = resolveConnectedSenderState({
+      evmWallet: {
+        address: undefined,
+        chainId: undefined,
+        isConnected: false,
+      },
+      e2eMockWallet: {
+        enabled: true,
+        address: EVM_ADDRESS,
+        chainId: 314159,
+      },
+    });
+
+    expect(state.connectedSender).toMatchObject({
+      kind: 'evm',
+      address: getAddress(EVM_ADDRESS),
+      chainId: 314159,
+      networkKey: 'calibration',
+      nativePrefix: 't',
+    });
+    expect(state.balanceSource).toEqual({
+      kind: 'evm-wagmi',
+      enabled: true,
+      address: getAddress(EVM_ADDRESS),
+      chainId: 314159,
+    });
+  });
+
+  it('surfaces planned native Filecoin providers without enabling review or send', () => {
+    const state = resolveConnectedSenderState({
+      evmWallet: {
+        address: undefined,
+        chainId: undefined,
+        isConnected: false,
+      },
+      nativeFilecoinProviders: [getPlannedNativeProvider()],
+    });
+
+    expect(state.connectedSender).toBeUndefined();
+    expect(state.nativeFilecoin).toMatchObject({
+      status: 'planned',
+      hasConnectableProvider: false,
+      hasSignableProvider: false,
+      unavailableReason:
+        'Native Filecoin wallet signing is scaffolded, but no browser provider has been verified for production use yet.',
+    });
+    expect(state.canUseLiveSendPath).toBe(false);
+  });
+
+  it('models native f1/t1 senders as unsupported by the live send path until signing is wired', () => {
+    const mainnetState = resolveConnectedSenderState({
+      evmWallet: {
+        address: undefined,
+        chainId: undefined,
+        isConnected: false,
+      },
+      nativeFilecoinSender: getNativeSender(MAINNET_F1),
+    });
+    const calibrationState = resolveConnectedSenderState({
+      evmWallet: {
+        address: undefined,
+        chainId: undefined,
+        isConnected: false,
+      },
+      nativeFilecoinSender: getNativeSender(CALIBRATION_T1),
+    });
+
+    expect(mainnetState.connectedSender).toMatchObject({
+      kind: 'native-filecoin',
+      address: MAINNET_F1,
+      networkKey: 'mainnet',
+      nativePrefix: 'f',
+    });
+    expect(mainnetState.canUseLiveSendPath).toBe(false);
+    expect(mainnetState.liveSendPathUnavailableReason).toBe(
+      'Native Filecoin wallet review and send are not wired into the live app yet.',
+    );
+    expect(mainnetState.balanceSource).toEqual({
+      kind: 'native-filecoin-lotus',
+      enabled: true,
+      address: MAINNET_F1,
+      networkKey: 'mainnet',
+      reason: undefined,
+    });
+
+    expect(calibrationState.connectedSender).toMatchObject({
+      kind: 'native-filecoin',
+      address: CALIBRATION_T1,
+      networkKey: 'calibration',
+      nativePrefix: 't',
+    });
+    expect(calibrationState.canUseLiveSendPath).toBe(false);
+  });
+
+  it('formats sender display addresses without converting native f1/t1 senders to 0x', () => {
+    const mainnetEvmState = resolveConnectedSenderState({
+      evmWallet: {
+        address: EVM_ADDRESS,
+        chainId: 314,
+        isConnected: true,
+      },
+    });
+    const calibrationEvmState = resolveConnectedSenderState({
+      evmWallet: {
+        address: EVM_ADDRESS,
+        chainId: 314159,
+        isConnected: true,
+      },
+    });
+    const unsupportedEvmState = resolveConnectedSenderState({
+      evmWallet: {
+        address: EVM_ADDRESS,
+        chainId: 1,
+        isConnected: true,
+      },
+    });
+    const nativeState = resolveConnectedSenderState({
+      evmWallet: {
+        address: undefined,
+        chainId: undefined,
+        isConnected: false,
+      },
+      nativeFilecoinSender: getNativeSender(CALIBRATION_T1),
+    });
+
+    expect(getSenderDisplayAddress(mainnetEvmState.connectedSender!)).toBe(
+      toF4(getAddress(EVM_ADDRESS), 'f'),
+    );
+    expect(getSenderDisplayAddress(calibrationEvmState.connectedSender!)).toBe(
+      toF4(getAddress(EVM_ADDRESS), 't'),
+    );
+    expect(getSenderDisplayAddress(unsupportedEvmState.connectedSender!)).toBe(
+      getAddress(EVM_ADDRESS),
+    );
+    expect(getSenderDisplayAddress(nativeState.connectedSender!)).toBe(CALIBRATION_T1);
+  });
+});

--- a/src/lib/senders/connectedSender.ts
+++ b/src/lib/senders/connectedSender.ts
@@ -1,0 +1,266 @@
+import { convertEthToDelegatedAddress } from '../../utils/addressConverter';
+import type {
+  NetworkPrefix,
+  SendFilNetworkConfig,
+  SendFilNetworkKey,
+  SupportedChainId,
+} from '../networks';
+import { createEvmConnectedSender } from './senderModel';
+import type {
+  ConnectedSender,
+  NativeFilecoinConnectedSender,
+  NativeFilecoinWalletProvider,
+  SenderProviderMetadata,
+} from './types';
+
+export interface EvmWalletConnectionSnapshot {
+  address?: string;
+  chainId?: number;
+  isConnected: boolean;
+}
+
+export interface E2eMockWalletSnapshot {
+  enabled: boolean;
+  address: `0x${string}`;
+  chainId: SupportedChainId;
+}
+
+export type SenderBalanceSource =
+  | {
+      kind: 'none';
+      enabled: false;
+      reason:
+        | 'disconnected'
+        | 'unsupported-network'
+        | 'unsupported-sender'
+        | 'balance-disabled';
+    }
+  | {
+      kind: 'evm-wagmi';
+      enabled: boolean;
+      address: `0x${string}`;
+      chainId: SupportedChainId;
+    }
+  | {
+      kind: 'native-filecoin-lotus';
+      enabled: boolean;
+      address: string;
+      networkKey: SendFilNetworkKey;
+      reason?: string;
+    };
+
+export interface NativeFilecoinProviderReadiness {
+  status: 'hidden' | 'planned' | 'disabled' | 'available';
+  providers: Array<SenderProviderMetadata & { kind: 'native-filecoin-wallet' }>;
+  hasConnectableProvider: boolean;
+  hasSignableProvider: boolean;
+  unavailableReason?: string;
+}
+
+export interface ConnectedSenderState {
+  connectedSender?: ConnectedSender;
+  isConnected: boolean;
+  address?: string;
+  chainId?: number;
+  connectedNetwork?: SendFilNetworkConfig;
+  networkStatus: 'disconnected' | 'supported' | 'unsupported';
+  hasSupportedConnectedNetwork: boolean;
+  isUnsupportedConnectedNetwork: boolean;
+  expectedNetworkPrefix?: NetworkPrefix;
+  canUseLiveSendPath: boolean;
+  liveSendPathUnavailableReason?: string;
+  balanceSource: SenderBalanceSource;
+  nativeFilecoin: NativeFilecoinProviderReadiness;
+}
+
+export interface ResolveConnectedSenderStateParams {
+  evmWallet: EvmWalletConnectionSnapshot;
+  e2eMockWallet?: E2eMockWalletSnapshot;
+  nativeFilecoinSender?: NativeFilecoinConnectedSender;
+  nativeFilecoinProviders?: NativeFilecoinWalletProvider[];
+  balanceQueriesEnabled?: boolean;
+}
+
+function summarizeNativeFilecoinProviders(
+  providers: NativeFilecoinWalletProvider[] = [],
+): NativeFilecoinProviderReadiness {
+  const providerMetadata = providers.map((provider) => provider.metadata);
+  const hasConnectableProvider = providerMetadata.some(
+    (provider) => provider.capabilities.canConnect,
+  );
+  const hasSignableProvider = providerMetadata.some(
+    (provider) =>
+      provider.capabilities.canSignBatch &&
+      provider.capabilities.canSubmit &&
+      provider.capabilities.oneApprovalPerBatch,
+  );
+  const unavailableReason = providerMetadata.find(
+    (provider) => provider.unavailableReason,
+  )?.unavailableReason;
+
+  if (providerMetadata.length === 0) {
+    return {
+      status: 'hidden',
+      providers: [],
+      hasConnectableProvider: false,
+      hasSignableProvider: false,
+    };
+  }
+
+  if (hasConnectableProvider && hasSignableProvider) {
+    return {
+      status: 'available',
+      providers: providerMetadata,
+      hasConnectableProvider,
+      hasSignableProvider,
+      unavailableReason,
+    };
+  }
+
+  const hasDisabledProvider = providerMetadata.some(
+    (provider) => provider.status === 'disabled',
+  );
+
+  return {
+    status: hasDisabledProvider ? 'disabled' : 'planned',
+    providers: providerMetadata,
+    hasConnectableProvider,
+    hasSignableProvider,
+    unavailableReason,
+  };
+}
+
+function resolveEvmWalletSnapshot(
+  evmWallet: EvmWalletConnectionSnapshot,
+  e2eMockWallet?: E2eMockWalletSnapshot,
+): EvmWalletConnectionSnapshot {
+  if (!e2eMockWallet?.enabled) {
+    return evmWallet;
+  }
+
+  return {
+    address: e2eMockWallet.address,
+    chainId: e2eMockWallet.chainId,
+    isConnected: true,
+  };
+}
+
+function resolveSenderBalanceSource(
+  sender: ConnectedSender | undefined,
+  balanceQueriesEnabled: boolean,
+): SenderBalanceSource {
+  if (!sender) {
+    return {
+      kind: 'none',
+      enabled: false,
+      reason: 'disconnected',
+    };
+  }
+
+  if (sender.networkStatus !== 'supported' || !sender.network) {
+    return {
+      kind: 'none',
+      enabled: false,
+      reason: 'unsupported-network',
+    };
+  }
+
+  if (!balanceQueriesEnabled) {
+    return {
+      kind: 'none',
+      enabled: false,
+      reason: 'balance-disabled',
+    };
+  }
+
+  if (sender.kind === 'evm') {
+    return {
+      kind: 'evm-wagmi',
+      enabled: true,
+      address: sender.address,
+      chainId: sender.network.chainId,
+    };
+  }
+
+  return {
+    kind: 'native-filecoin-lotus',
+    enabled: sender.provider.capabilities.canReadBalance,
+    address: sender.address,
+    networkKey: sender.networkKey,
+    reason: sender.provider.capabilities.canReadBalance
+      ? undefined
+      : 'Native Filecoin balance reads are not supported by this provider.',
+  };
+}
+
+function getLiveSendPathUnavailableReason(
+  sender: ConnectedSender | undefined,
+): string | undefined {
+  if (!sender) {
+    return undefined;
+  }
+
+  if (sender.kind === 'native-filecoin') {
+    return 'Native Filecoin wallet review and send are not wired into the live app yet.';
+  }
+
+  if (!sender.canSignBatch) {
+    return 'The connected sender cannot sign a SendFIL batch.';
+  }
+
+  return undefined;
+}
+
+export function resolveConnectedSenderState({
+  evmWallet,
+  e2eMockWallet,
+  nativeFilecoinSender,
+  nativeFilecoinProviders = [],
+  balanceQueriesEnabled = true,
+}: ResolveConnectedSenderStateParams): ConnectedSenderState {
+  const evmSnapshot = resolveEvmWalletSnapshot(evmWallet, e2eMockWallet);
+  const evmSender = createEvmConnectedSender(evmSnapshot);
+  const connectedSender = nativeFilecoinSender ?? evmSender;
+  const nativeFilecoin = summarizeNativeFilecoinProviders(nativeFilecoinProviders);
+  const isConnected = Boolean(connectedSender);
+  const networkStatus = connectedSender
+    ? connectedSender.networkStatus
+    : 'disconnected';
+  const liveSendPathUnavailableReason =
+    getLiveSendPathUnavailableReason(connectedSender);
+
+  return {
+    connectedSender,
+    isConnected,
+    address: connectedSender?.address,
+    chainId: connectedSender?.chainId,
+    connectedNetwork: connectedSender?.network,
+    networkStatus,
+    hasSupportedConnectedNetwork: networkStatus === 'supported',
+    isUnsupportedConnectedNetwork: networkStatus === 'unsupported',
+    expectedNetworkPrefix: connectedSender?.nativePrefix,
+    canUseLiveSendPath:
+      connectedSender?.kind === 'evm' &&
+      connectedSender.canSignBatch &&
+      connectedSender.networkStatus === 'supported' &&
+      !liveSendPathUnavailableReason,
+    liveSendPathUnavailableReason,
+    balanceSource: resolveSenderBalanceSource(
+      connectedSender,
+      balanceQueriesEnabled,
+    ),
+    nativeFilecoin,
+  };
+}
+
+export function getSenderDisplayAddress(sender: ConnectedSender): string {
+  if (sender.kind === 'native-filecoin') {
+    return sender.address;
+  }
+
+  if (!sender.network) {
+    return sender.address;
+  }
+
+  return convertEthToDelegatedAddress(sender.address, sender.network.chainId);
+}

--- a/src/lib/senders/index.ts
+++ b/src/lib/senders/index.ts
@@ -1,3 +1,5 @@
+export * from './connectedSender';
 export * from './nativeFilecoinProvider';
 export * from './senderModel';
 export * from './types';
+export * from './useConnectedSender';

--- a/src/lib/senders/useConnectedSender.ts
+++ b/src/lib/senders/useConnectedSender.ts
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { useAccount, useChainId } from 'wagmi';
+import { getNativeFilecoinWalletProviders } from './nativeFilecoinProvider';
+import {
+  resolveConnectedSenderState,
+  type ConnectedSenderState,
+  type E2eMockWalletSnapshot,
+} from './connectedSender';
+import type {
+  NativeFilecoinConnectedSender,
+  NativeFilecoinWalletProvider,
+} from './types';
+
+export interface UseConnectedSenderOptions {
+  e2eMockWallet?: E2eMockWalletSnapshot;
+  nativeFilecoinSender?: NativeFilecoinConnectedSender;
+  nativeFilecoinProviders?: NativeFilecoinWalletProvider[];
+  balanceQueriesEnabled?: boolean;
+}
+
+export function useConnectedSender({
+  e2eMockWallet,
+  nativeFilecoinSender,
+  nativeFilecoinProviders: configuredNativeFilecoinProviders,
+  balanceQueriesEnabled = true,
+}: UseConnectedSenderOptions = {}): ConnectedSenderState {
+  const account = useAccount();
+  const chainId = useChainId();
+  const nativeFilecoinProviders = React.useMemo(
+    () =>
+      configuredNativeFilecoinProviders ??
+      getNativeFilecoinWalletProviders(),
+    [configuredNativeFilecoinProviders],
+  );
+
+  return React.useMemo(
+    () =>
+      resolveConnectedSenderState({
+        evmWallet: {
+          address: account.address,
+          chainId,
+          isConnected: account.isConnected,
+        },
+        e2eMockWallet,
+        nativeFilecoinSender,
+        nativeFilecoinProviders,
+        balanceQueriesEnabled,
+      }),
+    [
+      account.address,
+      account.isConnected,
+      balanceQueriesEnabled,
+      chainId,
+      e2eMockWallet,
+      nativeFilecoinProviders,
+      nativeFilecoinSender,
+    ],
+  );
+}


### PR DESCRIPTION
## Summary

Adds the next native sender foundation layer by centralizing the live connected-sender state behind a sender-model adapter. The existing EVM/wagmi sender remains the only live review/send-capable path, while native Filecoin sender models and provider placeholders are represented as planned/unsupported capabilities that cannot enable review or send.

This does not add native Filecoin wallet connection, native signing, native submission, Ledger support, or any UI that claims native sending is production-ready.

## What changed

- Added `resolveConnectedSenderState(...)` and `useConnectedSender(...)` to derive the live sender, network state, balance source, display address, and native provider readiness from one model.
- Refactored `App.tsx` to consume the connected-sender adapter for review gating, network prefix validation inputs, chain/network labels, and EVM balance reads.
- Updated `NetworkBanner` to accept a connected sender model while preserving wagmi fallback behavior.
- Updated `CustomConnectButton` address display to use the sender display helper, preserving `0x` to `f4/t4` display for EVM senders without converting native `f1/t1` sender addresses.
- Added focused sender-state tests for EVM behavior, E2E mock behavior, unsupported networks, planned native providers, native `f1/t1` modeling, and display formatting.
- Updated invariants docs to record that the live App now uses the connected-sender adapter and still blocks native sender review/send.

## Validation

- `yarn test src/lib/senders/__tests__/connectedSender.test.ts src/lib/senders/__tests__/senderModel.test.ts src/lib/senders/__tests__/nativeFilecoinProvider.test.ts src/__tests__/app.invariants.test.tsx src/__tests__/App.test.tsx`
- `yarn test src/lib/senders/__tests__/connectedSender.test.ts src/__tests__/app.invariants.test.tsx src/__tests__/App.test.tsx`
- `yarn lint`
- `yarn typecheck`
- `yarn test`
- `yarn build`

`yarn build` still emits the existing Vite large chunk warning.