### PR TITLE
Improve mobile layout with footer social links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import {
   getNetworkConfig,
   getSupportedNetworkByChainId,
   getSupportedNetworkListLabel,
+  type NetworkPrefix,
 } from './lib/networks';
 import { useConnectedSender } from './lib/senders';
 
@@ -81,6 +82,16 @@ function createEmptyManualInteractions(count = 3): ManualRecipientInteraction[] 
     addressTouched: false,
     amountTouched: false,
   }));
+}
+
+function getManualRecipientAddressPlaceholder(
+  rowIndex: number,
+  expectedNetworkPrefix?: NetworkPrefix,
+): string {
+  const nativePrefix = expectedNetworkPrefix === 't' ? 't' : 'f';
+  const placeholderPattern = [`${nativePrefix}1...`, `${nativePrefix}4...`, '0x...'];
+
+  return placeholderPattern[rowIndex % placeholderPattern.length];
 }
 
 function createEmptyRecipientValidationResult(): RecipientValidationResult {
@@ -1164,13 +1175,10 @@ f1cj...,3.3`;
                                 Receiver
                               </label>
                               <input
-                                placeholder={
-                                  expectedNetworkPrefix === 't'
-                                    ? 't1..., t4..., or 0x...'
-                                    : expectedNetworkPrefix === 'f'
-                                      ? 'f1..., f4..., or 0x...'
-                                      : 'f1..., t1..., f4..., t4..., or 0x...'
-                                }
+                                placeholder={getManualRecipientAddressPlaceholder(
+                                  index,
+                                  expectedNetworkPrefix,
+                                )}
                                 value={recipient.address}
                                 onChange={(event) =>
                                   updateRecipient(index, 'address', event.target.value)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -311,6 +311,34 @@ function ConfigurationChoiceGroup({
   );
 }
 
+function SocialLinks({ className = '' }: { className?: string }) {
+  return (
+    <div
+      className={`flex items-center justify-center gap-2 text-sm text-slate-500 ${className}`.trim()}
+    >
+      <a
+        href="https://x.com/send_fil"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="font-medium transition-colors hover:text-slate-900"
+      >
+        X
+      </a>
+      <span className="text-slate-300" aria-hidden="true">
+        |
+      </span>
+      <a
+        href="https://github.com/sendfil-io/sendfil"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="font-medium transition-colors hover:text-slate-900"
+      >
+        GitHub
+      </a>
+    </div>
+  );
+}
+
 export default function App() {
   const e2eMockWallet = React.useMemo(
     () => ({
@@ -676,7 +704,7 @@ export default function App() {
 
   const reviewHint = React.useMemo(() => {
     if (!isConnected) {
-      return 'Connect a wallet to confirm the target network before review and send.';
+      return 'Connect a wallet to review transaction';
     }
 
     if (isNetworkMismatch) {
@@ -878,7 +906,7 @@ f1cj...,3.3`;
 
   return (
     <div className="min-h-screen bg-[#f4f6fb] text-slate-900">
-      <div className="min-h-screen lg:flex">
+      <div className="flex min-h-screen flex-col lg:flex-row">
         <aside className="flex flex-col border-b border-slate-200/80 bg-white/90 px-5 pb-6 pt-0 backdrop-blur lg:w-72 lg:border-b-0 lg:border-r lg:px-6 lg:pb-8">
           <div className="-mx-5 mb-8 flex items-center justify-center bg-gradient-to-r from-[#1F69FF] via-[#22A6E2] to-[#3CD4A0] px-5 py-[26px] lg:-mx-6 lg:px-6">
             <img
@@ -912,28 +940,8 @@ f1cj...,3.3`;
             />
           </div>
 
-          <div className="mt-auto pt-8">
-            <div className="flex items-center justify-center gap-2 text-sm text-slate-500">
-              <a
-                href="https://x.com/send_fil"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-medium transition-colors hover:text-slate-900"
-              >
-                X
-              </a>
-              <span className="text-slate-300" aria-hidden="true">
-                |
-              </span>
-              <a
-                href="https://github.com/sendfil-io/sendfil"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-medium transition-colors hover:text-slate-900"
-              >
-                GitHub
-              </a>
-            </div>
+          <div className="mt-auto hidden pt-8 lg:block">
+            <SocialLinks />
           </div>
 
         </aside>
@@ -1368,6 +1376,10 @@ f1cj...,3.3`;
             </div>
           </div>
         </main>
+
+        <footer className="border-t border-slate-200/80 bg-white/90 px-5 py-6 backdrop-blur lg:hidden">
+          <SocialLinks />
+        </footer>
       </div>
 
       <ReviewTransactionModal

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -227,6 +227,32 @@ describe('App confirm flow', () => {
     await flushAsyncWork();
   }
 
+  it('cycles manual address placeholders by row and restarts for added rows', async () => {
+    await act(async () => {
+      root.render(<App />);
+    });
+
+    expect(getElementByTestId(container, 'recipient-address-0')).toHaveProperty(
+      'placeholder',
+      'f1...',
+    );
+    expect(getElementByTestId(container, 'recipient-address-1')).toHaveProperty(
+      'placeholder',
+      'f4...',
+    );
+    expect(getElementByTestId(container, 'recipient-address-2')).toHaveProperty(
+      'placeholder',
+      '0x...',
+    );
+
+    click(getButton(container, '+ Add recipient'));
+
+    expect(getElementByTestId(container, 'recipient-address-3')).toHaveProperty(
+      'placeholder',
+      'f1...',
+    );
+  });
+
   it('calls executeBatch with fee rows in partial mode', async () => {
     executeBatchMock.mockImplementation(async () => {
       setMockExecutionSnapshot({


### PR DESCRIPTION
## Summary

- Extract a reusable `SocialLinks` component for X and GitHub links.
- On small screens, show social links in a mobile footer; on `lg+`, keep them in the sidebar as before.
- Use a column layout on mobile (`flex-col`) so the footer sits below main content.
- Shorten the disconnected-wallet review hint to "Connect a wallet to review transaction".

## Test plan

- [ ] Resize to mobile width: social links appear in the bottom footer, not in the sidebar.
- [ ] Resize to desktop (`lg+`): social links remain in the sidebar footer area; mobile footer is hidden.
- [ ] Verify X and GitHub links open correctly in a new tab.
- [ ] With wallet disconnected, confirm the review hint shows the updated copy.


Made with [Cursor](https://cursor.com)