### PR TITLE
Update CSV upload copy and remove helper text

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1431,8 +1431,7 @@ f1cj...,3.3`;
                 <div className="border-b border-slate-100 px-6 py-5 sm:px-8">
                   <h2 className="text-lg font-semibold text-slate-950">CSV Upload</h2>
                   <p className="mt-1 text-sm text-slate-500">
-                    Import a prepared batch using the template format, then review the parsed
-                    recipients before sending.
+                    Import a batch of recipients and amounts using the template format.
                   </p>
                 </div>
 

--- a/src/components/CSVUpload.tsx
+++ b/src/components/CSVUpload.tsx
@@ -195,16 +195,11 @@ export const CSVUpload: React.FC<CSVUploadProps> = ({
             <p className="mb-4 max-w-md text-sm text-slate-600">
               Drag and drop your CSV file here, or click to browse
             </p>
-            <p className="text-sm text-slate-500">Expected format: receiverAddress, value</p>
             {expectedNetworkPrefix ? (
               <p className="mt-2 text-xs text-slate-400">
                 Current network expects native addresses that start with {expectedNetworkPrefix}...
               </p>
-            ) : (
-              <p className="mt-2 text-xs text-slate-400">
-                Connect a wallet to lock the batch to mainnet or Calibration before review.
-              </p>
-            )}
+            ) : null}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- Update the CSV Upload panel description to “Import a batch of recipients and amounts using the template format.”
- Remove the dropzone helper text for the expected CSV format and disconnected-wallet network hint.
- Keep the existing connected-network prefix hint when a wallet/network is available.

## Validation

- `yarn --ignore-engines lint`
- `yarn --ignore-engines typecheck`