### PR TITLE
[codex] Update build status docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,27 @@
 # SendFIL
 
-SendFIL is a client-only Vite SPA for batch sending FIL. Senders can disperse FIL from a single-signer or multi-sig to one or many f1, f2, f4, or 0x addresses.
+SendFIL is a client-only Vite SPA for batch sending FIL. The live app currently supports single-signer EVM/FEVM senders and native Filecoin `f1`/`t1` senders through the Standard batch path. Multi-sig sender support remains planned work.
 
 ## Current live execution surface
 
 - Single-signer FEVM batch execution through `Multicall3.aggregate3Value(...)` plus `FilForwarder`.
-- Filecoin Mainnet and Calibration wallet flow through wagmi/RainbowKit with `metaMaskWallet` and `walletConnectWallet`.
-- Review-step gas estimation and send execution now use the same FEVM batch builder and the same selected error mode.
+- Filecoin Mainnet and Calibration EVM wallet flow through wagmi/RainbowKit with MetaMask, Brave Wallet, and WalletConnect.
+- Native Filecoin wallet rows for FilSnap and Ledger. Native `f1`/`t1` senders use one native `InvokeEVM` message that carries the same Standard batch payload.
+- Review-step gas estimation and send execution use the same Standard batch builder.
 - Duplicate recipients are warnings that require explicit acknowledgment before send.
+- Submit-time balance recheck is wired for the EVM/wagmi sender path and the native Filecoin sender path.
 
 ## Error handling modes
 
-- `PARTIAL` is the default. Successful internal calls can still finalize even if another call fails.
-- `ATOMIC` is all-or-nothing. Any failing internal call reverts the entire batch and no transfer is finalized.
+- `PARTIAL` is the live UI default and the only selectable mode in the current `App.tsx` flow. Successful internal calls can still finalize even if another call fails.
+- `ATOMIC` is implemented in the lower transaction layer by setting `allowFailure=false` for every Multicall3 call, and review/failure copy exists in `ReviewTransactionModal`. It is not currently selectable in the live app UI; choosing Atomic opens an unavailable-capability notice and leaves the batch on Partial.
 
 Recommended usage:
 
 - Use `PARTIAL` when best-effort delivery is acceptable and you want the batch to keep going.
-- Use `ATOMIC` when every recipient must succeed together or the batch should fail as one unit.
+- Use `ATOMIC` once the UI selector is wired when every recipient must succeed together or the batch should fail as one unit.
 
-When an atomic preflight fails, SendFIL blocks submission and explains that the whole batch would revert. When an atomic transaction fails after submission, the failure copy explicitly states that no transfer was finalized.
+Current implementation note: the transaction hooks and mock adapter can execute/preflight ATOMIC batches when called directly, but the live UI hardcodes `PARTIAL` until the selector is intentionally enabled.
 
 ## Telemetry
 
@@ -33,6 +35,8 @@ Payloads include:
 - `errorMode`
 - `recipientCount`
 - `totalValueAttoFil`
+- `networkKey`
+- `chainId`
 - preflight/simulation result
 - final transaction status
 - normalized error category
@@ -40,9 +44,13 @@ Payloads include:
 ## Known limitations
 
 - `ThinBatch` is still UI-visible but not live.
-- Filecoin-native signer flows are not wired into the live app path.
+- `ATOMIC` is transaction-layer-ready but blocked by the live UI selector.
 - Contract-recipient blocking (`eth_getCode`) is not implemented yet.
-- Balance is checked during review, but there is not yet a second submit-time balance recheck.
+- There is no centralized-exchange `0x` warning flow yet.
+- There is no past-transactions sidebar or stuck-transaction guidance in the main user flow yet.
+- Native Filecoin provider support has not been exhaustively verified across target browser, hardware, and network-switching environments.
+- Native account derivation currently uses adapter defaults; account/index selection UX is not implemented.
+- High-precision amount validation accepts up to 18 decimal places, but the live `App.tsx` value path still converts validated amounts to JavaScript `Number` before fee calculation and execution. A fully string/bigint-safe amount pipeline remains a money-safety hardening task.
 
 ## Environment setup
 
@@ -85,7 +93,7 @@ yarn dev
 yarn lint
 yarn test
 yarn typecheck
-yarn test:e2e tests/e2e/review-flow.spec.ts
+yarn test:e2e:smoke
 ```
 
 ## Calibration smoke test
@@ -98,4 +106,4 @@ yarn test:e2e tests/e2e/review-flow.spec.ts
 
 ## Design note
 
-See [docs/atomic-error-handling.md](docs/atomic-error-handling.md) for the ATOMIC-mode execution contract, error taxonomy, telemetry schema, and rollout notes.
+See [docs/atomic-error-handling.md](docs/atomic-error-handling.md) for the ATOMIC-mode transaction-layer contract, current UI gate, error taxonomy, telemetry schema, and rollout notes.

--- a/docs/atomic-error-handling.md
+++ b/docs/atomic-error-handling.md
@@ -1,32 +1,37 @@
 # ATOMIC Error Handling
 
-This note documents the current ATOMIC batch execution behavior in `sendfil`.
+This note documents the current ATOMIC batch execution boundary in `sendfil`.
 
 ## Scope
 
-Current live scope:
+Current transaction-layer scope:
 
 - `Standard` FEVM batch execution only
 - single-signer wallet path
-- Filecoin Mainnet wagmi config
-- `PARTIAL` and `ATOMIC` error handling in the live App flow
+- Filecoin Mainnet and Calibration network config
+- `PARTIAL` and `ATOMIC` behavior in the batch builder, execution hooks, error mapper, telemetry, and review modal copy
+
+Current live UI scope:
+
+- `PARTIAL` is the only selectable mode in `App.tsx`.
+- Selecting `ATOMIC` opens the unavailable-capability modal and leaves the batch on `PARTIAL`.
+- `App.tsx` currently passes `PARTIAL` into review estimation and send submission.
 
 Out of scope:
 
 - `ThinBatch`
-- Filecoin-native signer execution in the main UI
-- end-to-end Calibration rollout
+- making `ATOMIC` user-selectable in the live app UI
 
 ## Semantic contract
 
 - `PARTIAL`: internal calls set `allowFailure=true`. Successful transfers may finalize even if another call fails.
 - `ATOMIC`: internal calls set `allowFailure=false`. Any failing internal call reverts the full `aggregate3Value(...)` transaction.
 
-Both modes still encode through `aggregate3Value(...)`. There is no separate `aggregate3(...)` encoding path in this repo today. The all-or-revert guarantee comes from `allowFailure=false` on every call plus the live UI wiring that now propagates `errorMode` from configuration through preflight and send.
+Both modes still encode through `aggregate3Value(...)`. There is no separate `aggregate3(...)` encoding path in this repo today. The all-or-revert guarantee comes from `allowFailure=false` on every call. That behavior is available to callers that pass `ATOMIC` into the transaction hooks, but the live `App.tsx` UI does not currently pass `ATOMIC`.
 
 ## Execution pipeline
 
-The active path is:
+The transaction-layer path is:
 
 1. `App.tsx` collects validated recipients plus fee rows.
 2. `useExecuteBatch` prepares a `PreparedBatchExecution` from the selected `errorMode`.
@@ -34,6 +39,8 @@ The active path is:
 4. ATOMIC execution reruns FEVM preflight before submission to block obvious full-batch reverts.
 5. The wallet submits the multicall transaction through wagmi.
 6. Receipt tracking updates pending, confirmed, or failed state with a normalized execution error.
+
+Current live-app caveat: in the present UI, step 2 always receives `PARTIAL` from `App.tsx`. The ATOMIC path above is covered by lower-level tests and component copy, but it is not reachable from the main user flow until the selector gate is removed and E2E coverage is updated.
 
 ## Error taxonomy
 
@@ -56,6 +63,8 @@ The mapper lives in `src/lib/transaction/errorHandling.ts`.
 - ATOMIC failed-state copy explicitly says that no transfers were finalized.
 - PARTIAL failed-state copy preserves the possibility that some transfers may already be finalized.
 
+Current live-app caveat: these ATOMIC copy rules are implemented in `ReviewTransactionModal`, but they only render when the modal receives an ATOMIC configuration from tests or lower-level callers.
+
 ## Telemetry
 
 The client emits structured telemetry from `src/lib/transaction/telemetry.ts`:
@@ -67,7 +76,7 @@ The client emits structured telemetry from `src/lib/transaction/telemetry.ts`:
 - `batch_confirmed`
 - `batch_failed`
 
-Each event includes `errorMode`, `recipientCount`, `totalValueAttoFil`, and any available gas estimate, transaction hash, or normalized error category.
+Each event includes `errorMode`, `recipientCount`, `totalValueAttoFil`, network identity, and any available gas estimate, transaction hash, or normalized error category.
 
 ## Test coverage
 
@@ -76,8 +85,8 @@ Implemented coverage:
 - unit tests for `allowFailure` invariants in `buildMulticallBatch`
 - unit tests for execution-error classification
 - component tests for ATOMIC review and failure messaging
-- Playwright review-flow coverage for ATOMIC selection, ATOMIC preflight blocking, and PARTIAL regression paths
+- Playwright review-flow coverage that asserts ATOMIC selection remains blocked in the live UI and that the batch continues with PARTIAL semantics
 
 ## Rollback
 
-The code does not currently ship a production feature flag for ATOMIC mode. Operational rollback would mean reverting the ATOMIC selection wiring in `App.tsx` and restoring the selector guard, while leaving the lower-level batch builder support intact.
+The code currently ships with the ATOMIC selector guard in place. Enabling ATOMIC in the live app should be a small but explicit product change: pass `batchConfiguration.errorHandling` into estimate/send, update E2E expectations, and keep `PARTIAL` as the default. Operational rollback would restore the selector guard while leaving the lower-level batch builder support intact.

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -22,7 +22,7 @@ Use this catalog before changing validation, network gating, review/send flow, R
 | `INV-ADDR-002` | Reject `f0` recipients | `implemented` | validation | `src/utils/__tests__/recipientValidation.test.ts`, `src/lib/transaction/__tests__/multicall.test.ts` |
 | `INV-ADDR-003` | Treat `0x` and `f4` twins as the same recipient identity internally | `partial` | validation, duplicate detection, transaction builder | `src/utils/__tests__/recipientValidation.test.ts`, `src/lib/transaction/__tests__/multicall.test.ts` |
 | `INV-AMT-001` | Reject blank, zero, and negative amounts | `implemented` | validation, amount parsing | `src/utils/__tests__/recipientValidation.test.ts` |
-| `INV-AMT-002` | Reject values with more than 18 decimal places | `implemented` | validation, amount parsing | `src/utils/__tests__/recipientValidation.test.ts` |
+| `INV-AMT-002` | Reject over-precise values and preserve exact accepted values | `partial` | validation, amount parsing, execution value preservation | `src/utils/__tests__/recipientValidation.test.ts` |
 | `INV-BATCH-001` | Enforce the 500-recipient cap | `implemented` | validation | `src/utils/__tests__/recipientValidation.test.ts` |
 | `INV-DUP-001` | Duplicate recipients require explicit confirmation before Send | `implemented` | duplicate detection, review UI gating | `src/utils/__tests__/recipientValidation.test.ts`, `src/components/__tests__/ReviewTransactionModal.test.tsx`, `tests/e2e/review-flow.spec.ts` |
 | `INV-NET-001` | Wrong network disables Send | `implemented` | network/wallet gating, review UI gating | `src/lib/senders/__tests__/connectedSender.test.ts`, `src/__tests__/app.invariants.test.tsx` |
@@ -54,9 +54,7 @@ validation
   - `it('trims surrounding whitespace before validating supported recipients')`
 
 ### Status
-`partial`
-
-Current repo note: duplicate detection already treats `0x` and `f4` twins as the same identity, but the FEVM batch builder does not yet normalize raw `0x` inputs and `f4` twins to the same exact target string form.
+`implemented`
 
 ## INV-ADDR-002 — Reject `f0` recipients
 
@@ -111,7 +109,12 @@ validation, duplicate detection, transaction builder
   - `it('INV-ADDR-003 canonicalizes 0x and f4 twins to the same EVM transfer target')`
 
 ### Status
-`implemented`
+`partial`
+
+Current repo note: duplicate detection already treats `0x` and `f4`/`t4` twins as the same identity.
+The transaction builder routes both raw `0x` and delegated EVM forms to direct EVM value transfers.
+Treat the broader DevSpec canonicalization requirement as partial until display, review, duplicate
+identity, and execution target normalization are deliberately documented as one end-to-end contract.
 
 ## INV-AMT-001 — Reject blank, zero, and negative amounts
 
@@ -139,7 +142,7 @@ validation, amount parsing
 ### Status
 `implemented`
 
-## INV-AMT-002 — Reject values with more than 18 decimal places
+## INV-AMT-002 — Reject over-precise values and preserve exact accepted values
 
 ### Rule
 FIL-denominated inputs may use at most 18 decimal places. Over-precise values must be rejected rather than rounded or truncated.
@@ -148,7 +151,7 @@ FIL-denominated inputs may use at most 18 decimal places. Over-precise values mu
 If precision silently changes, users can send the wrong value and review totals stop matching execution inputs.
 
 ### Execution boundary
-validation, amount parsing
+validation, amount parsing, execution value preservation
 
 ### Acceptance criteria
 - Whole values pass.
@@ -156,6 +159,7 @@ validation, amount parsing
 - 19 decimal places fail.
 - Over-precise rows are excluded from `validRecipients`.
 - Error copy communicates the 18-decimal rule.
+- Accepted 18-decimal values keep exact value semantics through fee calculation and execution.
 
 ### Tests
 - `src/utils/__tests__/recipientValidation.test.ts`
@@ -164,7 +168,12 @@ validation, amount parsing
   - `it('rejects values with more than 18 decimal places')`
 
 ### Status
-`implemented`
+`partial`
+
+Current repo note: the shared validator correctly accepts up to 18 decimal places and rejects more
+than 18. The live App still converts normalized amount strings to JavaScript `Number` values before
+fee calculation and execution, so exact end-to-end preservation for all valid 18-decimal FIL inputs
+remains a gap.
 
 ## INV-BATCH-001 — Enforce the 500-recipient cap
 

--- a/plan.md
+++ b/plan.md
@@ -98,11 +98,11 @@ Out of scope until then:
 ## Phase Status Overview
 
 - Phase 0: `Implemented in planning docs`
-- Phase 1: `Partial`
+- Phase 1: `Implemented`
 - Phase 2: `Partial`
 - Phase 3: `Partial`
-- Phase 4: `Planned`
-- Phase 5: `Planned`
+- Phase 4: `Partial`
+- Phase 5: `Partial`
 - Phase 6: `Blocked by external dependency`
 
 ## Phase 0: Planning Baseline
@@ -116,23 +116,22 @@ DevSpec requirements.
 
 ### Current gap
 
-The repo contains partial implementations and parallel transaction paths. Without an explicit
-baseline, future work risks building against the wrong architecture or treating spec-only behavior
-as already shipped.
+The original baseline captured a repo that still simulated the primary send path and had several
+mainnet-only assumptions. Many of those gaps have since been closed. The durable risk remains the
+same: future work must not treat roadmap/spec-only behavior as if it were wired into the live app.
 
 ### Deliverables
 
 - Document the current repo state and the intended v1 direction.
 - Define roadmap status labels and milestone layers.
 - Record the main implementation gaps that must shape sequencing:
-  - the primary send flow is simulated
-  - the Standard FEVM path exists but is not wired into the main UX
-  - review-time estimation currently uses a different path than intended submission
-  - validation differs between CSV and manual entry
-  - calibration support is only partial
-  - true `ATOMIC` vs `PARTIAL` behavior is not complete
+  - Standard FEVM send is live, but ThinBatch remains unavailable
+  - CSV and manual validation are shared, but EVM contract-recipient blocking is missing
+  - Calibration is represented across the active code paths, but still needs public-testnet and wallet/provider smoke verification
+  - lower transaction layers support `ATOMIC`, but the live App selector blocks it and submits `PARTIAL`
+  - native Filecoin senders are wired through FilSnap/Ledger rows, but hardware/browser verification and account/index UX remain gaps
+  - validated 18-decimal amount strings still pass through `Number` before fee and execution
   - ThinBatch is not deployed or enabled
-  - filecoin-native sender flows are not live
 
 ### Dependencies
 
@@ -152,7 +151,7 @@ as already shipped.
 
 ## Phase 1: Ship The Real Standard FEVM Path
 
-**Status:** `Partial`
+**Status:** `Implemented`
 
 ### Goal
 
@@ -161,10 +160,12 @@ estimation with the same execution model.
 
 ### Current gap
 
-- The main review flow still simulates signing, pending, and confirmation.
-- The repo already contains a Standard FEVM path based on Multicall3 + FilForwarder, but the live
-  app path does not use it.
-- Review-time estimation and submission do not currently use the same execution model.
+- No open Phase 1 gap remains for the EVM/FEVM Standard path.
+- The main EVM/FEVM review flow uses the real Standard path through `useExecuteBatch`.
+- Review-time estimation and submission are aligned through the same prepared Standard batch
+  configuration.
+- The live native Filecoin path also reuses the same Standard payload through one signed native
+  `InvokeEVM` message.
 
 ### Deliverables
 
@@ -213,11 +214,12 @@ that pipeline up to DevSpec parity for v1 safety requirements.
 
 ### Current gap
 
-- CSV and manual entry do not share the same validation model.
-- CSV currently rejects `0x` despite the DevSpec requiring support.
-- CSV does not enforce the DevSpec `500`-row maximum.
-- Manual entry validation is materially weaker than CSV validation.
-- Submit-time balance recheck and EVM contract recipient blocking are not implemented.
+- CSV and manual entry now share `validateRecipientRows(...)`.
+- `0x` recipients, network-prefix checks, duplicate warnings, duplicate acknowledgment, and the
+  `500`-recipient cap are active in the shared path.
+- Submit-time balance recheck is wired for both EVM/wagmi and native Filecoin sender paths.
+- Remaining gaps: EVM contract-recipient blocking, generic centralized-exchange caution copy, and
+  exact end-to-end amount preservation for 18-decimal FIL values.
 
 ### Deliverables
 
@@ -279,9 +281,11 @@ Make network behavior match the DevSpec end-to-end for both Filecoin Mainnet and
 
 ### Current gap
 
-- Mainnet support is primary; calibration behavior is only partially represented.
-- Wrong-network handling is warning-oriented rather than fully blocking.
-- Address-prefix, explorer-base, and network config behavior are not unified across the full flow.
+- Mainnet and Calibration are modeled through the shared network registry, wagmi config, validation,
+  explorer helpers, fee policy, and Lotus/FEVM env configuration.
+- Unsupported network state blocks review/send at the App boundary.
+- Remaining gap: public-testnet FEVM smoke coverage and real target-wallet verification are still
+  needed before calling Calibration production-verified end to end.
 
 ### Deliverables
 
@@ -317,28 +321,32 @@ Make network behavior match the DevSpec end-to-end for both Filecoin Mainnet and
 
 ## Phase 4: Add Spec-Required Execution Controls
 
-**Status:** `Planned`
+**Status:** `Partial`
 
 ### Goal
 
-Add the execution controls required by the DevSpec and implement true Standard-lane
-`PARTIAL` / `ATOMIC` semantics.
+Add the execution controls required by the DevSpec and finish making them live-selectable where
+the implementation and product risk posture allow it.
 
 ### Current gap
 
-- The repo does not yet present execution controls in the main flow.
-- `PARTIAL` and `ATOMIC` exist conceptually but are not both fully implemented behaviors.
-- ThinBatch is not available in the live flow.
+- The main flow presents execution-method and error-handling controls.
+- `Standard` and `PARTIAL` remain the only live selectable path.
+- Selecting `ThinBatch` or `ATOMIC` opens an unavailable-capability notice and preserves the current
+  safe selection.
+- Lower transaction layers support Standard-lane `ATOMIC` semantics when called directly, but
+  `src/App.tsx` currently hardcodes `PARTIAL` for live estimate/submit.
+- ThinBatch is not deployed/configured and has no live execution path.
 
 ### Deliverables
 
-- Add execution configuration to the product flow:
+- Keep execution configuration in the product flow:
   - `executionMethod: Standard | ThinBatch`
   - `errorMode: PARTIAL | ATOMIC`
 - Keep default selections as:
   - `Standard`
   - `PARTIAL`
-- Implement true Standard-lane atomic behavior rather than only modeling the option in types or UI.
+- Decide whether and when to remove the live UI gate for Standard-lane Atomic.
 - Ensure review, estimation, and submission all consume the same execution configuration.
 - Keep ThinBatch hidden or disabled unless deployment configuration is present.
 
@@ -350,7 +358,7 @@ Add the execution controls required by the DevSpec and implement true Standard-l
 
 ### Acceptance criteria
 
-- `PARTIAL` and `ATOMIC` are real behavioral modes, not labels only.
+- `PARTIAL` and `ATOMIC` are real behavioral modes when live-selectable, not labels only.
 - Standard remains the default execution method.
 - ThinBatch does not appear as available unless deployment/configuration prerequisites are present.
 
@@ -360,7 +368,7 @@ Add the execution controls required by the DevSpec and implement true Standard-l
 
 ## Phase 5: Add Filecoin-Native Sender Support For V1
 
-**Status:** `Planned`
+**Status:** `Partial`
 
 ### Goal
 
@@ -369,16 +377,19 @@ approval/message invariant.
 
 ### Current gap
 
-- The live wallet layer is EVM-centric.
-- Filecoin-native sender support is described in the DevSpec but is not present in the primary app.
-- Review, submission, and explorer behavior have not been unified across EVM and native senders.
+- The live wallet layer now includes EVM/RainbowKit plus native FilSnap and Ledger Filecoin rows.
+- Native senders reuse the shared validation, review, status, and Standard payload model through
+  `useExecuteNativeBatch`.
+- Remaining gaps: real FilSnap browser approval verification, physical Ledger network switching
+  verification, broader native wallet parity, and account/index selection UX.
 
 ### Deliverables
 
-- Add a filecoin-native sender connection and signing path for supported `f1` senders.
-- Build one native message that invokes the FEVM engine while preserving the one-approval invariant.
+- Maintain the filecoin-native sender connection and signing path for supported `f1`/`t1` senders.
+- Continue building one native message that invokes the FEVM engine while preserving the one-approval invariant.
 - Reuse the same validation, review, and transaction-status model as the EVM sender path.
 - Keep explorer behavior and status handling consistent across EVM and native senders.
+- Add account/index selection UX and complete hardware/browser verification.
 
 Implementation default for wallet integration:
 
@@ -397,13 +408,13 @@ Implementation default for wallet integration:
 
 ### Acceptance criteria
 
-- A supported `f1` sender can complete the same review and send flow through the main app.
+- A supported `f1`/`t1` sender can complete the same review and send flow through the main app.
 - One approval/message is preserved for single-signer native senders.
 - The same validation, guardrails, and status model apply across EVM and native sender flows.
 
 ### Blocked by
 
-- Native wallet-provider support and integration feasibility
+- Native wallet-provider browser/hardware verification and account/index UX
 
 ## Phase 6: ThinBatch Enablement And Remaining V1 UX
 
@@ -418,6 +429,7 @@ from the DevSpec.
 
 - ThinBatch is not deployed or configured.
 - The remaining v1 UX requirements are not fully present:
+  - generic EVM / centralized-exchange recipient caution
   - past transactions sidebar
   - stuck-transaction guidance
   - richer review details for debugging and routing visibility
@@ -427,6 +439,7 @@ from the DevSpec.
 - Enable ThinBatch once deployment/configuration is available.
 - Preserve the Standard-vs-ThinBatch distinction in review, send, and audit behavior.
 - Add remaining v1 UX called for by the DevSpec:
+  - generic caution for EVM recipients until a trustworthy exchange-address source exists
   - past transactions sidebar
   - stuck-transaction guidance that points users back to wallet-native controls
   - review details showing routing/type/debug information without losing the compact default view
@@ -475,6 +488,19 @@ Suggested logical contracts:
 - `ValidatedRecipient`
 - `ValidationIssue`
 - `ReviewModel`
+
+### Money/value model
+
+The live UI currently validates amount strings up to 18 decimals but then converts them into
+JavaScript `Number` values for the recipient model, fee calculation, and execution inputs. That is
+not a safe long-term interface for FIL amounts.
+
+Future work should lock an exact value model before changing fee or execution behavior:
+
+- preserve the user-entered normalized FIL string through review
+- derive attoFIL as `bigint` for execution
+- avoid `Number` for any value that can affect submitted FIL amounts
+- keep display formatting separate from execution math
 
 ### Transaction configuration model
 


### PR DESCRIPTION
## Summary

- Update README status language for the current Standard batch path, native sender rows, Atomic UI gate, and known limitations.
- Refresh the roadmap to distinguish implemented, partial, blocked, and verification-needed work.
- Clarify the Atomic error-handling doc so transaction-layer support is not described as live UI support.
- Tighten invariants around address canonicalization and exact 18-decimal amount preservation.

## Validation

- `yarn lint`
- `yarn typecheck`
- `yarn test`

## Notes

`AGENTS.md` and `DevSpecs/` are ignored in this repo, so the PR includes the tracked docs updates only.