### PR TITLE
[codex] Harden contract recipient guard

### DIFF
--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -45,6 +45,7 @@ validation
 - Valid `f1`, `f2`, `f3`, `f4`, and `0x` rows are accepted with positive amounts.
 - Accepted rows are returned in `validRecipients`.
 - Accepted rows do not also produce validation errors.
+- `f2/t2` actor recipients produce a non-blocking value-transfer notice.
 - Whitespace trimming stays invisible to the user.
 
 ### Tests
@@ -52,6 +53,7 @@ validation
   - `describe('INV-ADDR-001 recipient acceptance', ...)`
   - `it('accepts valid f1, f2, f3, f4, and 0x recipients through the shared validator')`
   - `it('trims surrounding whitespace before validating supported recipients')`
+  - `it('emits a non-blocking value-transfer notice for actor recipients')`
 
 ### Status
 `implemented`
@@ -296,7 +298,7 @@ Current repo note: this is implemented for the live EVM/wagmi sender path and th
 ## INV-RPC-001 — Contract recipients detected via `eth_getCode` are blocked
 
 ### Rule
-EVM recipients (`0x` or `f4`) with deployed bytecode must be blocked before Send can proceed, using the public-client `getCode` / `eth_getCode` path or an equivalent check.
+EVM recipients (`0x` or `f4`) with deployed bytecode must be blocked before Send can proceed, using the public-client `getCode` / `eth_getCode` path or an equivalent check. The check applies to the final prepared payment destinations, including app-appended fee rows.
 
 ### Why this matters
 The v1 product scope only supports EVM EOAs as `0x`/`f4` recipients. Contract recipients can absorb value in ways that do not match the batch sender’s intent.
@@ -309,18 +311,22 @@ RPC contract-recipient check, review UI gating
 - Empty code (`0x`) is treated as EOA-like and allowed.
 - Non-empty code blocks review/send.
 - Native `f1/f2/f3` recipients do not invoke this check.
+- Appended EVM fee rows are checked before estimate/send.
 - Send is disabled and execution is not triggered when any EVM contract recipient is present.
 
 ### Tests
 - `src/__tests__/contractRecipientGuard.test.tsx`
   - `describe('INV-RPC-001 contract recipient guard', ...)`
-  - `it('does not require getCode for native f1 recipients')`
+  - `it('does not require getCode for native Filecoin recipients')`
   - `it('blocks send when an EVM recipient resolves to deployed bytecode')`
+  - `it('blocks send when an f4 twin resolves to deployed bytecode')`
+  - `it('fails closed when EVM recipient code cannot be verified')`
+  - `it('checks appended EVM fee rows before estimating or sending')`
 
 ### Status
 `implemented`
 
-Current repo note: the FEVM review/send flow checks user-entered `0x` and `f4` recipients with `getCode` before review estimation and repeats the check before submit. Native `f1/f2/f3` recipients do not invoke this check. ThinBatch does not duplicate this product policy on-chain; the local guard applies consistently to Standard and ThinBatch.
+Current repo note: the FEVM review/send flow checks final payment destinations with `getCode` before review estimation and repeats the check before submit. That includes user-entered `0x` and `f4` recipients plus appended EVM fee rows. Native `f1/f2/f3` recipients do not invoke this check. ThinBatch does not duplicate this product policy on-chain; the local guard applies consistently to Standard and ThinBatch.
 
 ## INV-EXEC-001 — Review estimate and submission use the same execution config
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -491,7 +491,9 @@ export default function App() {
   const [isEstimatingGas, setIsEstimatingGas] = React.useState(false);
   const [gasEstimationError, setGasEstimationError] =
     React.useState<BatchExecutionError | undefined>(undefined);
+  const [isCheckingContractRecipients, setIsCheckingContractRecipients] = React.useState(false);
   const [contractRecipientErrors, setContractRecipientErrors] = React.useState<string[]>([]);
+  const contractRecipientCheckSequence = React.useRef(0);
   const [batchConfiguration, setBatchConfiguration] = React.useState<BatchConfiguration>(
     DEFAULT_BATCH_CONFIGURATION,
   );
@@ -776,25 +778,6 @@ export default function App() {
     [csvValidation.validRecipients, inputMode, manualValidation.validRecipients],
   );
 
-  React.useEffect(() => {
-    setContractRecipientErrors([]);
-  }, [connectedNetwork?.chainId, validRecipients]);
-
-  const checkEvmContractRecipients = React.useCallback(async (): Promise<string[]> => {
-    if (E2E_MOCK_WALLET_ENABLED) {
-      setContractRecipientErrors([]);
-      return [];
-    }
-
-    const errors = await validateNoEvmContractRecipients(
-      validRecipients,
-      contractRecipientClient,
-    );
-
-    setContractRecipientErrors(errors);
-    return errors;
-  }, [contractRecipientClient, validRecipients]);
-
   const feeComputation = React.useMemo(() => {
     if (validRecipients.length === 0) {
       return {
@@ -833,6 +816,43 @@ export default function App() {
       };
     }
   }, [connectedNetwork, validRecipients]);
+
+  React.useEffect(() => {
+    contractRecipientCheckSequence.current += 1;
+    setContractRecipientErrors([]);
+    setIsCheckingContractRecipients(false);
+  }, [connectedNetwork?.chainId, feeComputation.recipients]);
+
+  const checkEvmContractRecipients = React.useCallback(async (): Promise<string[]> => {
+    const checkId = contractRecipientCheckSequence.current + 1;
+    contractRecipientCheckSequence.current = checkId;
+
+    if (E2E_MOCK_WALLET_ENABLED) {
+      setContractRecipientErrors([]);
+      setIsCheckingContractRecipients(false);
+      return [];
+    }
+
+    setIsCheckingContractRecipients(true);
+
+    try {
+      const errors = await validateNoEvmContractRecipients(
+        feeComputation.recipients,
+        contractRecipientClient,
+      );
+
+      if (contractRecipientCheckSequence.current === checkId) {
+        setContractRecipientErrors(errors);
+      }
+
+      return errors;
+    } finally {
+      if (contractRecipientCheckSequence.current === checkId) {
+        setIsCheckingContractRecipients(false);
+      }
+    }
+  }, [contractRecipientClient, feeComputation.recipients]);
+
   const activeValidationErrors =
     inputMode === 'manual'
       ? [
@@ -1634,6 +1654,7 @@ f1cj...,3.3`;
         feeTotal={feeTotal}
         gasEstimate={gasEstimate}
         isEstimatingGas={isEstimatingGas}
+        isCheckingContractRecipients={isCheckingContractRecipients}
         gasEstimationError={gasEstimationError}
         walletBalance={walletBalance}
         insufficientBalance={insufficientBalance}

--- a/src/__tests__/contractRecipientGuard.test.tsx
+++ b/src/__tests__/contractRecipientGuard.test.tsx
@@ -2,16 +2,22 @@ import { act } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { JSDOM } from 'jsdom';
 import { createRoot, type Root } from 'react-dom/client';
-import { CoinType, newSecp256k1Address } from '@glif/filecoin-address';
+import { CoinType, newActorAddress, newSecp256k1Address } from '@glif/filecoin-address';
 import { getAddress } from 'viem';
 import App from '../App';
+import { toF4 } from '../utils/toF4';
 import type { RecipientValidationResult } from '../utils/recipientValidation';
 
 const FEE_A = '0x1111111111111111111111111111111111111111';
 const FEE_B = '0x2222222222222222222222222222222222222222';
 const CONTRACT_RECIPIENT = '0x1234567890abcdef1234567890abcdef12345678';
+const F4_CONTRACT_RECIPIENT = toF4(CONTRACT_RECIPIENT, 'f');
 const NATIVE_F1 = newSecp256k1Address(
   Uint8Array.from({ length: 33 }, (_, index) => index + 1),
+  CoinType.MAIN,
+).toString();
+const NATIVE_F2 = newActorAddress(
+  Uint8Array.from([1, 2, 3, 4]),
   CoinType.MAIN,
 ).toString();
 
@@ -113,6 +119,9 @@ describe('INV-RPC-001 contract recipient guard', () => {
   let root: Root;
 
   beforeEach(() => {
+    vi.stubEnv('VITE_FEE_ENABLED_MAINNET', 'false');
+    vi.stubEnv('VITE_FEE_ADDR_A_MAINNET', FEE_A);
+    vi.stubEnv('VITE_FEE_ADDR_B_MAINNET', FEE_B);
     vi.stubEnv('VITE_FEE_ADDR_A', FEE_A);
     vi.stubEnv('VITE_FEE_ADDR_B', FEE_B);
     vi.stubEnv('VITE_FEE_PERCENT', '1');
@@ -176,7 +185,25 @@ describe('INV-RPC-001 contract recipient guard', () => {
     dom.window.close();
   });
 
-  it('does not require getCode for native f1 recipients', async () => {
+  it('does not require getCode for native Filecoin recipients', async () => {
+    mockValidationResult = {
+      validRecipients: [
+        {
+          address: NATIVE_F1,
+          amount: '1',
+          lineNumber: 1,
+        },
+        {
+          address: NATIVE_F2,
+          amount: '2',
+          lineNumber: 2,
+        },
+      ],
+      errors: [],
+      warnings: [],
+      nonEmptyRowCount: 2,
+    };
+
     await act(async () => {
       root.render(<App />);
     });
@@ -219,6 +246,116 @@ describe('INV-RPC-001 contract recipient guard', () => {
     ) as HTMLButtonElement;
 
     expect(getCodeMock).toHaveBeenCalled();
+    expect(sendButton.disabled).toBe(true);
+
+    click(sendButton);
+    await flushAsyncWork();
+
+    expect(sendTransactionAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it('blocks send when an f4 twin resolves to deployed bytecode', async () => {
+    getCodeMock.mockResolvedValue('0x60016000');
+    mockValidationResult = {
+      validRecipients: [
+        {
+          address: F4_CONTRACT_RECIPIENT,
+          amount: '1',
+          lineNumber: 1,
+        },
+      ],
+      errors: [],
+      warnings: [],
+      nonEmptyRowCount: 1,
+    };
+
+    await act(async () => {
+      root.render(<App />);
+    });
+
+    click(getElementByTestId(container, 'review-batch-button'));
+    await flushAsyncWork();
+
+    const sendButton = getElementByTestId(
+      container,
+      'send-batch-button',
+    ) as HTMLButtonElement;
+
+    expect(getCodeMock).toHaveBeenCalledWith({
+      address: getAddress(CONTRACT_RECIPIENT),
+    });
+    expect(sendButton.disabled).toBe(true);
+
+    click(sendButton);
+    await flushAsyncWork();
+
+    expect(sendTransactionAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when EVM recipient code cannot be verified', async () => {
+    getCodeMock.mockRejectedValue(new Error('RPC unavailable'));
+    mockValidationResult = {
+      validRecipients: [
+        {
+          address: getAddress(CONTRACT_RECIPIENT),
+          amount: '1',
+          lineNumber: 1,
+        },
+      ],
+      errors: [],
+      warnings: [],
+      nonEmptyRowCount: 1,
+    };
+
+    await act(async () => {
+      root.render(<App />);
+    });
+
+    click(getElementByTestId(container, 'review-batch-button'));
+    await flushAsyncWork();
+
+    const sendButton = getElementByTestId(
+      container,
+      'send-batch-button',
+    ) as HTMLButtonElement;
+
+    expect(container.textContent).toContain(
+      'Could not verify EVM recipients for deployed contract code: RPC unavailable',
+    );
+    expect(sendButton.disabled).toBe(true);
+
+    click(sendButton);
+    await flushAsyncWork();
+
+    expect(sendTransactionAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it('checks appended EVM fee rows before estimating or sending', async () => {
+    vi.stubEnv('VITE_FEE_ENABLED_MAINNET', 'true');
+    getCodeMock.mockImplementation(
+      async ({ address }: { address: `0x${string}` }) =>
+        address.toLowerCase() === FEE_A.toLowerCase()
+          ? '0x60016000'
+          : '0x',
+    );
+
+    await act(async () => {
+      root.render(<App />);
+    });
+
+    click(getElementByTestId(container, 'review-batch-button'));
+    await flushAsyncWork();
+
+    const sendButton = getElementByTestId(
+      container,
+      'send-batch-button',
+    ) as HTMLButtonElement;
+
+    expect(getCodeMock).toHaveBeenCalledWith({ address: getAddress(FEE_A) });
+    expect(container.textContent).toContain(
+      `EVM contract recipients are not supported: ${FEE_A}.`,
+    );
+    expect(estimateGasMock).not.toHaveBeenCalled();
     expect(sendButton.disabled).toBe(true);
 
     click(sendButton);

--- a/src/components/ReviewTransactionModal.tsx
+++ b/src/components/ReviewTransactionModal.tsx
@@ -41,6 +41,7 @@ export interface ReviewTransactionModalProps {
   // Gas estimation
   gasEstimate?: GasEstimate;
   isEstimatingGas: boolean;
+  isCheckingContractRecipients?: boolean;
   gasEstimationError?: BatchExecutionError;
 
   // Wallet state
@@ -88,6 +89,7 @@ export const ReviewTransactionModal: React.FC<ReviewTransactionModalProps> = ({
   feeTotal,
   gasEstimate,
   isEstimatingGas,
+  isCheckingContractRecipients = false,
   gasEstimationError,
   walletBalance,
   insufficientBalance,
@@ -130,6 +132,7 @@ export const ReviewTransactionModal: React.FC<ReviewTransactionModalProps> = ({
     (requiresDuplicateConfirmation && !hasAcknowledgedDuplicateRecipients) ||
     insufficientBalance ||
     hasBlockingAtomicPreflightError ||
+    isCheckingContractRecipients ||
     isEstimatingGas ||
     transactionState !== 'review';
 
@@ -240,6 +243,18 @@ export const ReviewTransactionModal: React.FC<ReviewTransactionModalProps> = ({
           <p className="text-sm text-red-700 mt-1">
             Your wallet balance ({formatFil(walletBalance)}) is less than the required amount (
             {formatFil(grandTotal)}).
+          </p>
+        </div>
+      )}
+
+      {isCheckingContractRecipients && (
+        <div
+          className="mb-4 rounded-md border border-blue-200 bg-blue-50 p-4"
+          data-testid="contract-recipient-checking"
+        >
+          <h4 className="font-semibold text-blue-900">Checking EVM recipients</h4>
+          <p className="mt-1 text-sm text-blue-800">
+            SendFIL is verifying that 0x and f4 recipients do not have deployed contract code.
           </p>
         </div>
       )}

--- a/src/components/__tests__/ReviewTransactionModal.test.tsx
+++ b/src/components/__tests__/ReviewTransactionModal.test.tsx
@@ -243,6 +243,21 @@ describe('ReviewTransactionModal', () => {
     expect(getButton(container, 'Send').disabled).toBe(true);
   });
 
+  it('blocks send while EVM contract-recipient checks are pending', () => {
+    const props = getBaseProps();
+    props.isCheckingContractRecipients = true;
+
+    act(() => {
+      root.render(<ReviewTransactionModal {...props} />);
+    });
+
+    expect(container.textContent).toContain('Checking EVM recipients');
+    expect(container.textContent).toContain(
+      'SendFIL is verifying that 0x and f4 recipients do not have deployed contract code.',
+    );
+    expect(getButton(container, 'Send').disabled).toBe(true);
+  });
+
   it('renders atomic-specific failure guidance', () => {
     const props = getBaseProps();
     props.batchConfiguration = {

--- a/src/utils/__tests__/contractRecipientGuard.test.ts
+++ b/src/utils/__tests__/contractRecipientGuard.test.ts
@@ -1,17 +1,22 @@
 import { describe, expect, it, vi } from 'vitest';
+import { CoinType, newActorAddress } from '@glif/filecoin-address';
 import { getAddress } from 'viem';
 import { toF4 } from '../toF4';
 import { validateNoEvmContractRecipients } from '../contractRecipientGuard';
 
 const EVM_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
 const NATIVE_ADDRESS = 'f1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za';
+const NATIVE_ACTOR_ADDRESS = newActorAddress(
+  Uint8Array.from([1, 2, 3, 4]),
+  CoinType.MAIN,
+).toString();
 
 describe('validateNoEvmContractRecipients', () => {
   it('skips native Filecoin recipients', async () => {
     const getCode = vi.fn();
 
     const errors = await validateNoEvmContractRecipients(
-      [{ address: NATIVE_ADDRESS }],
+      [{ address: NATIVE_ADDRESS }, { address: NATIVE_ACTOR_ADDRESS }],
       { getCode },
     );
 

--- a/src/utils/__tests__/recipientValidation.test.ts
+++ b/src/utils/__tests__/recipientValidation.test.ts
@@ -8,6 +8,7 @@ import { getAddress } from 'viem';
 import { describe, expect, it } from 'vitest';
 import { toF4 } from '../toF4';
 import {
+  ACTOR_RECIPIENT_VALUE_TRANSFER_WARNING,
   DUPLICATE_RECIPIENT_WARNING_MARKER,
   validateRecipientRows,
 } from '../recipientValidation';
@@ -68,7 +69,9 @@ describe('INV-ADDR-001 recipient acceptance', () => {
     );
 
     expect(result.errors).toEqual([]);
-    expect(result.warnings).toEqual([]);
+    expect(result.warnings).toEqual([
+      `Recipient 2: ${ACTOR_RECIPIENT_VALUE_TRANSFER_WARNING}`,
+    ]);
     expect(result.validRecipients).toEqual([
       { address: MAINNET_F1, amount: '1.25', lineNumber: 1 },
       { address: MAINNET_F2, amount: '2', lineNumber: 2 },
@@ -94,12 +97,35 @@ describe('INV-ADDR-001 recipient acceptance', () => {
     );
 
     expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
     expect(result.validRecipients).toEqual([
       {
         address: MAINNET_F1,
         amount: '1.000000000000000001',
         lineNumber: 1,
       },
+    ]);
+  });
+
+  it('emits a non-blocking value-transfer notice for actor recipients', () => {
+    const mainnetResult = validateRecipientRows(
+      [{ address: MAINNET_F2, amount: '1' }],
+      { source: 'csv', expectedNetworkPrefix: 'f' },
+    );
+
+    expect(mainnetResult.errors).toEqual([]);
+    expect(mainnetResult.warnings).toEqual([
+      `Line 1: ${ACTOR_RECIPIENT_VALUE_TRANSFER_WARNING}`,
+    ]);
+
+    const calibrationResult = validateRecipientRows(
+      [{ address: CALIBRATION_T2, amount: '2' }],
+      { source: 'manual', expectedNetworkPrefix: 't' },
+    );
+
+    expect(calibrationResult.errors).toEqual([]);
+    expect(calibrationResult.warnings).toEqual([
+      `Recipient 1: ${ACTOR_RECIPIENT_VALUE_TRANSFER_WARNING}`,
     ]);
   });
 });
@@ -190,6 +216,7 @@ describe('INV-AMT-001 amount sign and presence rules', () => {
     );
 
     expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
     expect(result.validRecipients).toEqual([
       {
         address: MAINNET_F1,
@@ -356,6 +383,9 @@ describe('network-aware validation regression coverage', () => {
     );
 
     expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([
+      `Recipient 2: ${ACTOR_RECIPIENT_VALUE_TRANSFER_WARNING}`,
+    ]);
     expect(result.validRecipients).toEqual([
       { address: CALIBRATION_T1, amount: '1', lineNumber: 1 },
       { address: CALIBRATION_T2, amount: '2', lineNumber: 2 },

--- a/src/utils/recipientValidation.ts
+++ b/src/utils/recipientValidation.ts
@@ -27,6 +27,8 @@ export interface RecipientValidationResult {
 }
 
 export const DUPLICATE_RECIPIENT_WARNING_MARKER = 'Duplicate recipient matches';
+export const ACTOR_RECIPIENT_VALUE_TRANSFER_WARNING =
+  'Actor recipients receive a FIL value transfer only; SendFIL will not call actor methods.';
 
 interface AddressValidationResult {
   isValid: boolean;
@@ -62,6 +64,10 @@ function getRowLabel(
   lineNumber: number,
 ): string {
   return source === 'csv' ? `Line ${lineNumber}` : `Recipient ${lineNumber}`;
+}
+
+function isNativeActorAddress(address: string): boolean {
+  return /^[ft]2/.test(address);
 }
 
 function toAttoFil(amount: string): bigint {
@@ -217,6 +223,10 @@ export function validateRecipientRows(
       );
     } else {
       seenRecipients.set(addressValidation.duplicateKey!, rowLabel);
+    }
+
+    if (isNativeActorAddress(addressValidation.normalizedAddress)) {
+      warnings.push(`${rowLabel}: ${ACTOR_RECIPIENT_VALUE_TRANSFER_WARNING}`);
     }
 
     validRecipients.push({


### PR DESCRIPTION
## Summary

- Checks the final prepared payment destinations for EVM contract recipients before review estimation and again before submit, including app-appended EVM fee rows.
- Keeps `0x`/`f4` contract blocking as an app/RPC preflight guard; no ThinBatch contract or ThinBatch builder code is changed.
- Adds a non-blocking `f2/t2` actor-recipient notice: actor recipients receive a FIL value transfer only, and SendFIL will not call actor methods.
- Adds review modal pending UI while EVM contract-recipient checks are running, plus regression coverage for `f4` twins, RPC fail-closed behavior, native actor recipients, fee rows, and the actor warning.

## Validation

- `yarn test src/utils/__tests__/recipientValidation.test.ts src/utils/__tests__/contractRecipientGuard.test.ts src/__tests__/contractRecipientGuard.test.tsx`
- `yarn typecheck`
- `yarn test`
- `yarn lint`
- `yarn build`

Notes:

- `yarn build` succeeds with existing Vite/Rolldown dependency annotation and chunk-size warnings.