### PR TITLE
Harden native Filecoin submission recovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ VITE_LOTUS_RPC_URL_MAINNET=https://api.node.glif.io/rpc/v1
 # The state-read fallback is a final read-only safety net and is never used for MpoolPush.
 # Identical endpoint URLs are de-duplicated. Keep the general fallback equal to the
 # primary when no separately operated read/write provider has been selected.
+# The retired https://rpc.node.glif.io/rpc/v1 value is ignored if it remains in a deployment.
 VITE_LOTUS_RPC_FALLBACK_MAINNET=https://api.node.glif.io/rpc/v1
 VITE_LOTUS_RPC_STATE_READ_FALLBACK_MAINNET=https://rpc.ankr.com/filecoin
 VITE_LOTUS_RPC_URL_CALIBRATION=https://api.calibration.node.glif.io/rpc/v1

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -28,7 +28,7 @@ Use this catalog before changing validation, network gating, review/send flow, R
 | `INV-NET-001`   | Wrong network disables Send                                                                    | `implemented` | network/wallet gating, review UI gating                    | `src/lib/senders/__tests__/connectedSender.test.ts`, `src/__tests__/app.invariants.test.tsx`                                                                                                                                    |
 | `INV-BAL-001`   | Submit-time balance recheck blocks EVM sends when current balance is insufficient              | `implemented` | submit guard, wallet RPC                                   | `src/lib/transaction/__tests__/submitBalanceCheck.test.ts`, `src/lib/transaction/__tests__/useExecuteBatch.submitBalance.test.tsx`                                                                                              |
 | `INV-RPC-001`   | Contract recipients detected via `eth_getCode` are blocked                                     | `implemented` | RPC contract-recipient check, review UI gating             | `src/__tests__/contractRecipientGuard.test.tsx`, `src/utils/__tests__/contractRecipientGuard.test.ts`                                                                                                                           |
-| `INV-RPC-002`   | Lotus failover preserves deterministic errors and endpoint diagnostics                          | `implemented` | native Filecoin RPC transport                              | `src/lib/DataProvider/__tests__/DataProvider.test.ts`                                                                                                                                                                            |
+| `INV-RPC-002`   | Lotus failover preserves deterministic errors and endpoint diagnostics                          | `implemented` | native Filecoin RPC transport                              | `src/lib/DataProvider/__tests__/DataProvider.test.ts`, `src/lib/__tests__/networks.test.ts`                                                                                                                                       |
 | `INV-NATIVE-001` | Signed native messages retain a deterministic CID through submission uncertainty               | `implemented` | native signing, submission, confirmation                   | `src/lib/senders/__tests__/nativeFilecoinSubmission.test.ts`, `src/lib/senders/__tests__/nativeSignerLock.test.ts`, `src/lib/transaction/__tests__/useExecuteNativeBatch.test.tsx`, `src/lib/multisig/__tests__/useExecuteMultisigProposal.test.tsx`, `src/lib/multisig/__tests__/useMultisigs.lifecycle.test.tsx` |
 | `INV-EXEC-001`  | Review estimate and submission use the same execution config                                   | `implemented` | estimate/execute flow, transaction builder                 | `src/lib/transaction/__tests__/batchExecution.test.ts`, `src/lib/transaction/__tests__/thinBatch.test.ts`, `src/lib/transaction/__tests__/nativeBatchPreflight.test.ts`, `src/__tests__/app.invariants.test.tsx`                |
 | `INV-MSIG-001`  | Native multisig proposals preserve the prepared batch and approvals verify its exact semantics | `implemented` | native multisig preparation, approval guard, actor outcome | `src/lib/multisig/__tests__/proposalVerifier.test.ts`, `src/lib/multisig/__tests__/rpc.test.ts`, `src/lib/multisig/__tests__/useExecuteMultisigProposal.test.tsx`, `src/lib/multisig/__tests__/useMultisigs.lifecycle.test.tsx` |
@@ -423,6 +423,9 @@ native Filecoin RPC transport
 - HTTP status, JSON-RPC envelope, result presence, and response ID are validated before a result is accepted.
 - Identical primary, configured fallback, and state-read fallback URLs, including trailing-slash
   variants, are called only once.
+- The retired Mainnet `https://rpc.node.glif.io/rpc/v1` configured fallback, including
+  URL-equivalent host-case, default-port, and trailing-slash variants, is replaced with the primary
+  endpoint at runtime so stale deployment configuration cannot receive reads or writes.
 
 ### Tests
 
@@ -432,6 +435,10 @@ native Filecoin RPC transport
   - primary method-unavailable plus fallback transport diagnostics
   - malformed response, HTTP status, and response-ID validation
   - stale state-backend same-endpoint retry without write-method retry
+  - retired-fallback quarantine for reads and `MpoolPush`
+- `src/lib/__tests__/networks.test.ts`
+  - current and legacy retired-fallback configuration replacement
+  - canonical host-case, default-port, and trailing-slash handling
 
 ### Status
 
@@ -459,6 +466,8 @@ native signing, submission, confirmation
 - BLS messages use the unsigned message CID; secp256k1 and delegated signatures use the canonical
   signed-message CID.
 - The locally derived CID is available before `MpoolPush` begins and a returned CID must match it.
+- The live provider contract requires the CID-persistence callback and exposes no alternate batch
+  submission entrypoint that can bypass it.
 - Safety records accept only the canonical Filecoin message-CID form: CIDv1, DAG-CBOR,
   Blake2b-256, a 32-byte digest, and canonical lowercase unpadded base32.
 - The exact CID and operation snapshot are written to `sendfil.native-submissions.v1` before
@@ -472,6 +481,10 @@ native signing, submission, confirmation
   because the exact message may already have been added before the error was returned.
 - Native batch, multisig Create, Propose, Approve, and Cancel consumers poll the local CID after an
   ambiguous push response.
+- Once the CID callback has completed, every later provider exception remains uncertain regardless
+  of its JavaScript class; only an error raised before CID persistence may release the operation.
+- A known-CID uncertain outcome exposes status recheck, not a fresh-signature retry, and its copy
+  never claims that the transaction failed or that no transfers occurred.
 - Retryable confirmation-read failures remain pending within the bounded polling window instead of
   terminating the poll as an on-chain failure; exhaustion still preserves the exact-CID lock.
 - A missing receipt or an inconsistent success response never becomes a confirmed operation.
@@ -653,6 +666,8 @@ native multisig creation, actor identity, submit outcome
 - The connected signer must be included in the signer list and its balance must exceed the initial deposit before remote preflight begins.
 - The creator balance is re-read after gas estimation and immediately before signing; it must cover the initial deposit plus estimated creation gas.
 - A confirmed InitActor return is decoded and its network-correct robust multisig address is saved locally.
+- Confirmed creation saves the actor durably before clearing its recovery record; a save failure
+  retains the CID lock and blocks duplicate creation.
 - The exact signed message CID is derived before `MpoolPush`; ambiguous submission, polling failures,
   or unverifiable confirmed returns are shown as uncertain and retain a Filfox link.
 - Uncertain creation records survive remounts and block another Create for the same signer/network

--- a/src/components/ReviewTransactionModal.tsx
+++ b/src/components/ReviewTransactionModal.tsx
@@ -10,6 +10,7 @@ import {
   type BatchConfiguration,
 } from '../lib/batchConfiguration';
 import { ERROR_MODE_COPY, type BatchExecutionError } from '../lib/transaction/errorHandling';
+import { isCanonicalFilecoinMessageCid } from '../lib/DataProvider/filecoinMessageCid';
 import { getFilfoxMessageUrl } from '../lib/networks';
 
 export type TransactionState = 'review' | 'signing' | 'pending' | 'confirmed' | 'failed';
@@ -727,9 +728,12 @@ export const ReviewTransactionModal: React.FC<ReviewTransactionModalProps> = ({
       <p className="text-sm text-gray-500 text-center mb-2">
         {fundingMode === 'native-multisig'
           ? transactionHash
-            ? 'Do not assume the batch executed successfully. Inspect the proposal message CID before retrying.'
+            ? 'Do not assume the batch executed successfully. Inspect the proposal message CID before taking another action.'
             : 'No multisig proposal was submitted, so the batch did not execute.'
-          : errorModeCopy.failureSummary}
+          : isCanonicalFilecoinMessageCid(transactionHash) &&
+              transactionError?.recoverable === false
+            ? 'The original transaction may still execute. Do not submit another transaction while its status is unresolved.'
+            : errorModeCopy.failureSummary}
       </p>
       {renderStoredSubmissionDetails()}
       {transactionError?.hint && (

--- a/src/components/__tests__/ReviewTransactionModal.test.tsx
+++ b/src/components/__tests__/ReviewTransactionModal.test.tsx
@@ -476,6 +476,40 @@ describe('ReviewTransactionModal', () => {
     ).toBe(false);
   });
 
+  it('presents a known-CID native uncertainty as recheck-only', () => {
+    const props = getBaseProps();
+    props.transactionState = 'failed';
+    props.transactionHash =
+      'bafy2bzacebcodbmrjkfrr63lms3wevg2nmceh2666bd3x76lwtsa7iygj7beo';
+    props.onRecheckTransaction = vi.fn().mockResolvedValue(undefined);
+    props.transactionError = new BatchExecutionError({
+      category: 'RPC_FAILURE',
+      title: 'Native batch confirmation is uncertain',
+      message:
+        'SendFIL could not prove that the batch reached a terminal on-chain result.',
+      errorMode: 'ATOMIC',
+      stage: 'confirmation',
+      recoverable: false,
+    });
+
+    act(() => {
+      root.render(<ReviewTransactionModal {...props} />);
+    });
+
+    expect(container.textContent).toContain(
+      'The original transaction may still execute. Do not submit another transaction while its status is unresolved.',
+    );
+    expect(container.textContent).not.toContain(
+      'No transfers are finalized if any internal call fails.',
+    );
+    expect(
+      Array.from(container.querySelectorAll('button')).some(
+        (button) => button.textContent?.trim() === 'Try Again',
+      ),
+    ).toBe(false);
+    expect(getButton(container, 'Check status again')).toBeDefined();
+  });
+
   it('traps keyboard focus and restores the previously focused control on close', () => {
     const outsideButton = document.createElement('button');
     outsideButton.textContent = 'Outside';

--- a/src/lib/DataProvider/__tests__/DataProvider.test.ts
+++ b/src/lib/DataProvider/__tests__/DataProvider.test.ts
@@ -4,6 +4,7 @@ import { setupServer } from 'msw/node';
 const PRIMARY = 'http://primary';
 const FALLBACK = 'http://fallback';
 const STATE_READ_FALLBACK = 'http://state-read-fallback';
+const RETIRED_MAINNET_FALLBACK = 'https://rpc.node.glif.io/rpc/v1';
 const CALIBRATION_PRIMARY = 'http://calibration-primary';
 const CALIBRATION_FALLBACK = 'http://calibration-fallback';
 
@@ -698,6 +699,62 @@ describe('DataProvider', () => {
     await expect(
       callRpc('Filecoin.MpoolPush', [{ Message: {}, Signature: {} }], 'mainnet'),
     ).rejects.toThrow('transport error');
+    expect(stateReadFallbackRequests).toBe(0);
+  });
+
+  it('routes reads around a retired configured fallback to the independent read lane', async () => {
+    vi.stubEnv('VITE_LOTUS_RPC_FALLBACK_MAINNET', RETIRED_MAINNET_FALLBACK);
+    vi.stubEnv(
+      'VITE_LOTUS_RPC_STATE_READ_FALLBACK_MAINNET',
+      STATE_READ_FALLBACK,
+    );
+    let retiredFallbackRequests = 0;
+    let stateReadFallbackRequests = 0;
+
+    server.use(
+      http.post(PRIMARY, () => HttpResponse.text('unavailable', { status: 503 })),
+      http.post(RETIRED_MAINNET_FALLBACK, () => {
+        retiredFallbackRequests += 1;
+        return HttpResponse.error();
+      }),
+      http.post(STATE_READ_FALLBACK, ({ request }) => {
+        stateReadFallbackRequests += 1;
+        return jsonRpcResult(request, { Balance: '500000000000000000' });
+      }),
+    );
+
+    await expect(
+      callRpc('Filecoin.StateReadState', ['f03810106', []], 'mainnet'),
+    ).resolves.toMatchObject({ Balance: '500000000000000000' });
+    expect(retiredFallbackRequests).toBe(0);
+    expect(stateReadFallbackRequests).toBe(1);
+  });
+
+  it('never submits MpoolPush to a retired fallback or the read-only lane', async () => {
+    vi.stubEnv('VITE_LOTUS_RPC_FALLBACK_MAINNET', RETIRED_MAINNET_FALLBACK);
+    vi.stubEnv(
+      'VITE_LOTUS_RPC_STATE_READ_FALLBACK_MAINNET',
+      STATE_READ_FALLBACK,
+    );
+    let retiredFallbackRequests = 0;
+    let stateReadFallbackRequests = 0;
+
+    server.use(
+      http.post(PRIMARY, () => HttpResponse.error()),
+      http.post(RETIRED_MAINNET_FALLBACK, () => {
+        retiredFallbackRequests += 1;
+        return HttpResponse.error();
+      }),
+      http.post(STATE_READ_FALLBACK, () => {
+        stateReadFallbackRequests += 1;
+        return HttpResponse.error();
+      }),
+    );
+
+    await expect(
+      callRpc('Filecoin.MpoolPush', [{ Message: {}, Signature: {} }], 'mainnet'),
+    ).rejects.toThrow('transport error');
+    expect(retiredFallbackRequests).toBe(0);
     expect(stateReadFallbackRequests).toBe(0);
   });
 

--- a/src/lib/__tests__/networks.test.ts
+++ b/src/lib/__tests__/networks.test.ts
@@ -99,13 +99,29 @@ describe('networks', () => {
     });
   });
 
-  it('keeps an independent Mainnet state-read fallback when deployment fallback config is broken', () => {
-    vi.stubEnv('VITE_LOTUS_RPC_FALLBACK_MAINNET', 'https://rpc.node.glif.io/rpc/v1');
+  it('replaces URL-equivalent variants of the retired Mainnet fallback', () => {
+    vi.stubEnv('VITE_LOTUS_RPC_URL_MAINNET', 'https://api.node.glif.io/rpc/v1');
+    vi.stubEnv(
+      'VITE_LOTUS_RPC_FALLBACK_MAINNET',
+      'HTTPS://RPC.NODE.GLIF.IO:443/rpc/v1///',
+    );
     vi.stubEnv('VITE_LOTUS_RPC_STATE_READ_FALLBACK_MAINNET', '');
 
     expect(resolveLotusRpcConfig('mainnet')).toMatchObject({
-      fallback: 'https://rpc.node.glif.io/rpc/v1',
+      primary: 'https://api.node.glif.io/rpc/v1',
+      fallback: 'https://api.node.glif.io/rpc/v1',
       stateReadFallback: 'https://rpc.ankr.com/filecoin',
+    });
+  });
+
+  it('replaces the retired legacy Mainnet fallback when the current env is absent', () => {
+    vi.stubEnv('VITE_LOTUS_RPC_URL_MAINNET', 'https://api.node.glif.io/rpc/v1');
+    vi.stubEnv('VITE_LOTUS_RPC_FALLBACK_MAINNET', '');
+    vi.stubEnv('VITE_GLIF_RPC_URL_FALLBACK', 'https://rpc.node.glif.io/rpc/v1/');
+
+    expect(resolveLotusRpcConfig('mainnet')).toMatchObject({
+      primary: 'https://api.node.glif.io/rpc/v1',
+      fallback: 'https://api.node.glif.io/rpc/v1',
     });
   });
 

--- a/src/lib/multisig/__tests__/useExecuteMultisigProposal.test.tsx
+++ b/src/lib/multisig/__tests__/useExecuteMultisigProposal.test.tsx
@@ -987,10 +987,12 @@ describe('useExecuteMultisigProposal', () => {
     expect(latestHook?.submissionSnapshot).toBeUndefined();
   });
 
-  it('removes a proposal CID lock after a definitive post-signing RPC rejection', async () => {
+  it('keeps a proposal CID locked when the provider throws a plain post-CID error', async () => {
     const sender = getNativeSender();
     const provider = getProvider(10n ** 21n);
     const storage = dom.window.localStorage;
+    const confirmation = createDeferred<TransactionStatus>();
+    const pollMessageStatus = vi.fn(() => confirmation.promise);
 
     vi.mocked(provider.signAndSubmitMessage!).mockImplementation(
       async (_message, options) => {
@@ -1008,19 +1010,44 @@ describe('useExecuteMultisigProposal', () => {
       network: getNetworkConfig('calibration'),
       rpc: getRpc(),
       storage,
-      pollMessageStatus: vi.fn(),
+      pollMessageStatus,
     });
+
+    let first!: Promise<string>;
+    await act(async () => {
+      first = latestHook!.executeBatch(recipients, 'ATOMIC');
+      await expect(first).resolves.toBe(CID);
+    });
+
+    expect(readNativeSubmissionRecords(storage).records).toEqual([
+      expect.objectContaining({ cid: CID, identity: getStoredProposal().identity }),
+    ]);
+    expect(latestHook?.isIdentityLocked).toBe(true);
+    expect(latestHook?.isWalletMutationUnsafe).toBe(false);
+    expect(latestHook?.txHash).toBe(CID);
+    expect(latestHook?.submissionSnapshot).toMatchObject({ cid: CID });
+    expect(pollMessageStatus).toHaveBeenCalledWith(CID, 60, 5000, 'calibration');
+
+    expect(latestHook!.executeBatch(recipients, 'ATOMIC')).toBe(first);
+    expect(provider.signAndSubmitMessage).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      await expect(latestHook!.executeBatch(recipients, 'ATOMIC')).rejects.toMatchObject({
-        category: 'RPC_FAILURE',
+      confirmation.resolve({
+        cid: CID,
+        status: 'failed',
+        error: 'confirmation is still unavailable',
       });
+      await confirmation.promise;
+      await Promise.resolve();
     });
 
-    expect(readNativeSubmissionRecords(storage).records).toEqual([]);
-    expect(latestHook?.isIdentityLocked).toBe(false);
-    expect(latestHook?.isWalletMutationUnsafe).toBe(false);
-    expect(latestHook?.txHash).toBeUndefined();
-    expect(latestHook?.submissionSnapshot).toBeUndefined();
+    expect(latestHook?.state).toBe('failed');
+    expect(latestHook?.error).toMatchObject({
+      title: 'Multisig proposal confirmation is uncertain',
+      recoverable: false,
+    });
+    expect(readNativeSubmissionRecords(storage).records).toHaveLength(1);
+    expect(latestHook!.executeBatch(recipients, 'ATOMIC')).toBe(first);
+    expect(provider.signAndSubmitMessage).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/multisig/__tests__/useMultisigs.lifecycle.test.tsx
+++ b/src/lib/multisig/__tests__/useMultisigs.lifecycle.test.tsx
@@ -20,7 +20,7 @@ import type { FilecoinMessage, TransactionStatus } from '../../DataProvider/type
 import { createTestLockManager } from '../../senders/__tests__/testLockManager';
 import type { MultisigActorState, MultisigPendingProposal, NativeMultisigAddress } from '../types';
 import { bytesToParamsBase64 } from '../actorParams';
-import { readSavedMultisigs, saveMultisig } from '../storage';
+import { MULTISIG_STORAGE_KEY, readSavedMultisigs, saveMultisig } from '../storage';
 import {
   MULTISIG_UNCERTAIN_ACTION_STORAGE_KEY,
   readUncertainMultisigActions,
@@ -1061,6 +1061,135 @@ describe('useMultisigs selection lifecycle', () => {
   });
 
   it.each([
+    ['Error', () => new Error('wallet provider failed after broadcast')],
+    ['TypeError', () => new TypeError('Failed to fetch after broadcast')],
+  ])(
+    'retains and reconciles a computed Create CID after a plain %s',
+    async (_errorName, createError) => {
+      const provider = createProvider();
+      vi.mocked(provider.signAndSubmitMessage!).mockImplementation(async (_message, options) => {
+        await options?.onCidComputed?.(CID);
+        throw createError();
+      });
+      moduleMocks.preflightCreateMultisig.mockResolvedValue({
+        estimatedMessage: { To: 't01' } as FilecoinMessage,
+        gasEstimate: { estimatedFee: 1n },
+      });
+      const pollMessageStatus = vi.fn(
+        async (): Promise<TransactionStatus> => ({
+          cid: CID,
+          status: 'failed',
+          error: 'confirmation RPC timed out',
+        }),
+      );
+
+      await renderHook({
+        ...currentOptions,
+        provider,
+        pollMessageStatus,
+      });
+
+      let result!: CreateMultisigResult;
+      await act(async () => {
+        result = await latestHook!.createMultisig({
+          signers: [SIGNER_A],
+          threshold: 1,
+          initialDepositFil: '0',
+        });
+      });
+
+      expect(result).toMatchObject({
+        outcome: 'uncertain',
+        cid: CID,
+        warning: expect.stringContaining('after broadcast'),
+      });
+      expect(pollMessageStatus).toHaveBeenCalledWith(CID, 60, 5000, 'calibration');
+      expect(readUncertainMultisigActions(storage).creates).toMatchObject([
+        { status: 'uncertain', cid: CID, signerAddress: SIGNER_A },
+      ]);
+      expect(latestHook?.isCreateRetryBlocked).toBe(true);
+
+      await expect(
+        latestHook!.createMultisig({
+          signers: [SIGNER_A],
+          threshold: 1,
+          initialDepositFil: '0',
+        }),
+      ).rejects.toThrow('still has an uncertain result');
+      expect(provider.signAndSubmitMessage).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('retains the confirmed Create recovery lock when actor persistence fails', async () => {
+    const provider = createProvider();
+    const originalSetItem = storage.setItem.bind(storage);
+    vi.spyOn(storage, 'setItem').mockImplementation((key, value) => {
+      if (key === MULTISIG_STORAGE_KEY) {
+        throw new DOMException('simulated crash while saving actor', 'QuotaExceededError');
+      }
+
+      originalSetItem(key, value);
+    });
+    moduleMocks.preflightCreateMultisig.mockResolvedValue({
+      estimatedMessage: { To: 't01' } as FilecoinMessage,
+      gasEstimate: { estimatedFee: 1n },
+    });
+    const pollMessageStatus = vi.fn(
+      async (): Promise<TransactionStatus> => ({
+        cid: CID,
+        status: 'confirmed',
+        receipt: {
+          ExitCode: 0,
+          Return: createExecReturnBase64(),
+          GasUsed: 100,
+        },
+      }),
+    );
+
+    await renderHook({
+      ...currentOptions,
+      provider,
+      pollMessageStatus,
+    });
+
+    let result!: CreateMultisigResult;
+    await act(async () => {
+      result = await latestHook!.createMultisig({
+        signers: [SIGNER_A],
+        threshold: 1,
+        initialDepositFil: '0',
+      });
+    });
+
+    expect(result).toMatchObject({
+      outcome: 'confirmed',
+      cid: CID,
+      createdAddress: CREATED_MULTISIG,
+      warning: expect.stringContaining('recovery lock was retained'),
+    });
+    if (result.outcome !== 'confirmed') {
+      throw new Error('Expected confirmed multisig creation');
+    }
+    expect(result.savedMultisig).toBeUndefined();
+    expect(readSavedMultisigs('calibration', storage).map((item) => item.address)).not.toContain(
+      CREATED_MULTISIG,
+    );
+    expect(readUncertainMultisigActions(storage).creates).toMatchObject([
+      { status: 'uncertain', cid: CID, signerAddress: SIGNER_A },
+    ]);
+    expect(latestHook?.isCreateRetryBlocked).toBe(true);
+
+    await expect(
+      latestHook!.createMultisig({
+        signers: [SIGNER_A],
+        threshold: 1,
+        initialDepositFil: '0',
+      }),
+    ).rejects.toThrow('still has an uncertain result');
+    expect(provider.signAndSubmitMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
     {
       label: 'a different signer',
       sender: () => createSender(SIGNER_B),
@@ -1755,6 +1884,85 @@ describe('useMultisigs selection lifecycle', () => {
     expect(latestHook?.isProposalRetryBlocked).toBe(false);
     expect(readUncertainMultisigActions(storage).proposals).toEqual([]);
   });
+
+  it.each([
+    {
+      action: 'approve' as const,
+      createError: () => new Error('approval provider failed after broadcast'),
+    },
+    {
+      action: 'cancel' as const,
+      createError: () => new TypeError('cancellation fetch failed after broadcast'),
+    },
+  ])(
+    'retains and reconciles a computed CID when $action throws a plain provider error',
+    async ({ action, createError }) => {
+      const proposal: MultisigPendingProposal =
+        action === 'approve'
+          ? createProposal()
+          : {
+              ...createProposal(),
+              proposer: 't01001',
+              proposerIdAddress: 't01001',
+              approvals: ['t01001'],
+              approvalIdAddresses: ['t01001'],
+              connectedSignerHasApproved: true,
+              canApprove: false,
+              canCancel: true,
+            };
+      const provider = createProvider();
+      vi.mocked(provider.signAndSubmitMessage!).mockImplementation(async (_message, options) => {
+        await options?.onCidComputed?.(CID);
+        throw createError();
+      });
+      moduleMocks.loadActorState.mockResolvedValue(createActorState(MULTISIG_A));
+      moduleMocks.loadPendingProposals.mockResolvedValue([proposal]);
+      moduleMocks.preflightProposalAction.mockResolvedValue({
+        estimatedMessage: {} as FilecoinMessage,
+        gasEstimate: { estimatedFee: 1n },
+      });
+      const pollMessageStatus = vi.fn(
+        async (): Promise<TransactionStatus> => ({
+          cid: CID,
+          status: 'failed',
+          error: 'confirmation RPC timed out',
+        }),
+      );
+
+      await renderHook({
+        ...currentOptions,
+        provider,
+        pollMessageStatus,
+      });
+
+      act(() => latestHook!.selectMultisig(MULTISIG_A));
+      await flushAsyncWork();
+      const submitAction = () =>
+        action === 'approve'
+          ? latestHook!.approveProposal(proposal)
+          : latestHook!.cancelProposal(proposal);
+
+      await act(async () => {
+        await expect(submitAction()).resolves.toBe(CID);
+      });
+      await flushAsyncWork();
+
+      expect(pollMessageStatus).toHaveBeenCalledWith(CID, 60, 5000, 'calibration');
+      expect(latestHook?.proposalActionState).toMatchObject({
+        action,
+        status: 'uncertain',
+        cid: CID,
+        error: expect.stringContaining('after broadcast'),
+      });
+      expect(readUncertainMultisigActions(storage).proposals).toMatchObject([
+        { action, status: 'uncertain', cid: CID, multisigAddress: MULTISIG_A },
+      ]);
+      expect(latestHook?.isProposalRetryBlocked).toBe(true);
+
+      await expect(submitAction()).rejects.toThrow('still has an uncertain result');
+      expect(provider.signAndSubmitMessage).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it('blocks every multisig action for the signer while another actor has an uncertain CID', async () => {
     const proposal = createProposal();

--- a/src/lib/multisig/useExecuteMultisigProposal.ts
+++ b/src/lib/multisig/useExecuteMultisigProposal.ts
@@ -833,29 +833,13 @@ export function useExecuteMultisigProposal({
                 );
                 lockedCid = submission.cid;
               } catch (cause) {
-                if (!isNativeFilecoinSubmissionUncertainError(cause)) {
-                  if (persistedCid) {
-                    const cleanupError = removeNativeSubmissionRecord(
-                      executionIdentity,
-                      persistedCid,
-                      storage,
-                    );
-
-                    if (cleanupError) {
-                      throw createMultisigSubmissionStorageError(
-                        cleanupError,
-                        errorMode,
-                      );
-                    }
-
-                    setSubmissionSnapshot(undefined);
-                    setTxHash(undefined);
-                  }
-
+                if (persistedCid) {
+                  lockedCid = persistedCid;
+                } else if (isNativeFilecoinSubmissionUncertainError(cause)) {
+                  lockedCid = cause.cid;
+                } else {
                   throw cause;
                 }
-
-                lockedCid = cause.cid;
               }
 
               if (!persistedCid) {

--- a/src/lib/multisig/useMultisigs.ts
+++ b/src/lib/multisig/useMultisigs.ts
@@ -1126,21 +1126,18 @@ export function useMultisigs({
                 throw error;
               }
 
-              if (!isNativeFilecoinSubmissionUncertainError(error)) {
-                if (cid) {
-                  const safetyState = uncertainCreateIdentities.current.get(actionIdentity);
-                  const persistenceError = safetyState
-                    ? clearCreateSafetyState(safetyState)
-                    : undefined;
-                  cid = undefined;
-
-                  if (persistenceError) {
-                    throw new Error(
-                      `${error instanceof Error ? error.message : 'Multisig submission failed.'} ${persistenceError}`,
-                    );
-                  }
+              if (cid) {
+                if (!safetyLockPersisted) {
+                  persistComputedCid(cid, false);
                 }
+                submissionUncertaintyDetail =
+                  error instanceof Error
+                    ? error.message
+                    : 'The wallet provider failed after computing the signed message CID.';
+                return;
+              }
 
+              if (!isNativeFilecoinSubmissionUncertainError(error)) {
                 throw error;
               }
 
@@ -1247,9 +1244,6 @@ export function useMultisigs({
           );
         }
 
-        const safetyState = uncertainCreateIdentities.current.get(actionIdentity);
-        const safetyClearError = safetyState ? clearCreateSafetyState(safetyState) : undefined;
-
         const saveResult = saveMultisigResult(
           {
             address: robustAddress,
@@ -1260,6 +1254,10 @@ export function useMultisigs({
           storage,
         );
         const savedItem = saveResult.multisigs.find((item) => item.address === robustAddress);
+        const actorSavedDurably = Boolean(savedItem && saveResult.persisted);
+        const safetyState = uncertainCreateIdentities.current.get(actionIdentity);
+        const safetyClearError =
+          actorSavedDurably && safetyState ? clearCreateSafetyState(safetyState) : undefined;
         const isCurrentCreateIdentity = currentCreateIdentityRef.current === actionIdentity;
         let result: CreateMultisigResult;
 
@@ -1276,7 +1274,7 @@ export function useMultisigs({
             createdAddress: robustAddress,
             warning:
               `The multisig was created at ${robustAddress}, but it was not saved locally. ${saveResult.error}` +
-              (safetyClearError ? ` ${safetyClearError}` : ''),
+              ' Its recovery lock was retained; restore storage and recheck this CID instead of creating another multisig.',
           };
         } else {
           if (isCurrentCreateIdentity) {
@@ -1296,12 +1294,10 @@ export function useMultisigs({
             cid,
             outcome: 'confirmed',
             createdAddress: robustAddress,
-            savedMultisig: savedItem,
-            warning: savedItem
+            savedMultisig: actorSavedDurably ? savedItem : undefined,
+            warning: actorSavedDurably
               ? safetyClearError
-              : `The multisig was created at ${robustAddress}, but SendFIL could not find it in local storage. Save this address manually.${
-                  safetyClearError ? ` ${safetyClearError}` : ''
-                }`,
+              : `The multisig was created at ${robustAddress}, but SendFIL could not verify that it was saved durably. Its recovery lock was retained; restore storage and recheck this CID instead of creating another multisig.`,
           };
         }
 
@@ -1486,13 +1482,16 @@ export function useMultisigs({
         storage,
       );
       const savedItem = saveResult.multisigs.find((item) => item.address === robustAddress);
-      const persistenceError = clearCreateSafetyState(uncertainState);
+      const actorSavedDurably = Boolean(savedItem && saveResult.persisted);
+      const persistenceError = actorSavedDurably
+        ? clearCreateSafetyState(uncertainState)
+        : undefined;
       const warningParts = [
         saveResult.error
-          ? `The multisig was created at ${robustAddress}, but it was not saved locally. ${saveResult.error}`
-          : savedItem
+          ? `The multisig was created at ${robustAddress}, but it was not saved locally. ${saveResult.error} Its recovery lock was retained; restore storage and recheck this CID instead of creating another multisig.`
+          : actorSavedDurably
             ? undefined
-            : `The multisig was created at ${robustAddress}, but SendFIL could not find it in local storage. Save this address manually.`,
+            : `The multisig was created at ${robustAddress}, but SendFIL could not verify that it was saved durably. Its recovery lock was retained; restore storage and recheck this CID instead of creating another multisig.`,
         persistenceError,
       ].filter(Boolean);
 
@@ -1772,21 +1771,18 @@ export function useMultisigs({
                 throw error;
               }
 
-              if (!isNativeFilecoinSubmissionUncertainError(error)) {
-                if (cid) {
-                  const safetyState = uncertainProposalActionIdentities.current.get(actionIdentity);
-                  const persistenceError = safetyState
-                    ? clearProposalSafetyState(safetyState)
-                    : undefined;
-                  cid = undefined;
-
-                  if (persistenceError) {
-                    throw new Error(
-                      `${error instanceof Error ? error.message : `Failed to submit multisig ${action}.`} ${persistenceError}`,
-                    );
-                  }
+              if (cid) {
+                if (!safetyLockPersisted) {
+                  persistComputedCid(cid, false);
                 }
+                submissionUncertaintyDetail =
+                  error instanceof Error
+                    ? error.message
+                    : `The wallet provider failed after computing the signed multisig ${action} CID.`;
+                return;
+              }
 
+              if (!isNativeFilecoinSubmissionUncertainError(error)) {
                 throw error;
               }
 

--- a/src/lib/networks.ts
+++ b/src/lib/networks.ts
@@ -39,6 +39,10 @@ const THINBATCH_MAINNET_DEFAULT =
 const THINBATCH_CALIBRATION_DEFAULT =
   '0x67fE9e377CD2F554629E266Ba91F53AA652EAdEB' as const;
 
+const RETIRED_MAINNET_LOTUS_RPC_URLS = new Set([
+  'https://rpc.node.glif.io/rpc/v1',
+]);
+
 const LEGACY_ENV_WARNINGS = new Set<string>();
 
 const NETWORK_METADATA: Record<
@@ -93,6 +97,38 @@ export const SUPPORTED_WAGMI_CHAINS = [filecoin, filecoinCalibration] as const;
 function readEnv(name: string): string | undefined {
   const value = (import.meta.env as Record<string, string | undefined>)[name];
   return value && value.length > 0 ? value : undefined;
+}
+
+function normalizeRpcUrl(url: string): string {
+  const trimmed = url.trim();
+
+  try {
+    const parsed = new URL(trimmed);
+    parsed.hash = '';
+    parsed.pathname = parsed.pathname.replace(/\/+$/, '') || '/';
+    return parsed.toString();
+  } catch {
+    return trimmed.replace(/\/+$/, '');
+  }
+}
+
+function resolveConfiguredLotusFallback(
+  key: SendFilNetworkKey,
+  primary: string,
+  configuredFallback: string | undefined,
+): string {
+  if (!configuredFallback) {
+    return primary;
+  }
+
+  if (
+    key === 'mainnet' &&
+    RETIRED_MAINNET_LOTUS_RPC_URLS.has(normalizeRpcUrl(configuredFallback))
+  ) {
+    return primary;
+  }
+
+  return configuredFallback;
 }
 
 function warnLegacyEnvUsage(legacyEnvName: string, replacementEnvName: string): void {
@@ -263,13 +299,14 @@ export function resolveLotusRpcConfig(key: SendFilNetworkKey): {
       isMainnet ? 'VITE_LOTUS_RPC_URL_MAINNET' : 'VITE_LOTUS_RPC_URL_CALIBRATION',
       isMainnet ? 'VITE_GLIF_RPC_URL_PRIMARY' : undefined,
     ) ?? NETWORK_METADATA[key].defaultLotusRpcUrl;
-  const fallback =
+  const configuredFallback =
     readEnvWithLegacy(
       isMainnet
         ? 'VITE_LOTUS_RPC_FALLBACK_MAINNET'
         : 'VITE_LOTUS_RPC_FALLBACK_CALIBRATION',
       isMainnet ? 'VITE_GLIF_RPC_URL_FALLBACK' : undefined,
-    ) ?? primary;
+    );
+  const fallback = resolveConfiguredLotusFallback(key, primary, configuredFallback);
   const stateReadFallback =
     readEnv(
       isMainnet

--- a/src/lib/senders/__tests__/nativeFilecoinSubmission.test.ts
+++ b/src/lib/senders/__tests__/nativeFilecoinSubmission.test.ts
@@ -75,6 +75,10 @@ const DELEGATED_SIGNED_MESSAGE: SignedMessage = {
 const DELEGATED_SIGNED_MESSAGE_CID =
   'bafy2bzacebpekbxp7qyk4xx5r7es3t77sqcgdq5c7osfow4ayvbyyafwl4sxk';
 
+const PERSIST_LOCAL_CID = {
+  onCidComputed: () => undefined,
+};
+
 // Immutable vectors above come from Filecoin Mainnet block
 // bafy2bzacedpk7crcxfy5y4eyy34hqduvuliwjcblm3gervekqkjucfgknb7e2 via
 // Filecoin.ChainGetBlockMessages. Lotus defines the CID and CBOR behavior here:
@@ -111,7 +115,12 @@ describe('native Filecoin MpoolPush uncertainty', () => {
     const submit = vi.fn(async () => ({ '/': SECP_SIGNED_MESSAGE_CID }));
 
     await expect(
-      submitSignedNativeFilecoinMessage(SECP_SIGNED_MESSAGE, 'mainnet', submit),
+      submitSignedNativeFilecoinMessage(
+        SECP_SIGNED_MESSAGE,
+        'mainnet',
+        submit,
+        PERSIST_LOCAL_CID,
+      ),
     ).resolves.toEqual({ cid: SECP_SIGNED_MESSAGE_CID });
     expect(submit).toHaveBeenCalledWith(SECP_SIGNED_MESSAGE, 'mainnet');
   });
@@ -158,6 +167,20 @@ describe('native Filecoin MpoolPush uncertainty', () => {
     expect(submit).not.toHaveBeenCalled();
   });
 
+  it('fails closed before MpoolPush when the required CID callback is missing', async () => {
+    const submit = vi.fn(async () => ({ '/': SECP_SIGNED_MESSAGE_CID }));
+
+    await expect(
+      submitSignedNativeFilecoinMessage(
+        SECP_SIGNED_MESSAGE,
+        'mainnet',
+        submit,
+        undefined as never,
+      ),
+    ).rejects.toThrow();
+    expect(submit).not.toHaveBeenCalled();
+  });
+
   it('retains the deterministic CID when a node may accept the message but loses its response', async () => {
     const transportFailure = new RpcProviderError('response lost', {
       method: 'Filecoin.MpoolPush',
@@ -175,6 +198,7 @@ describe('native Filecoin MpoolPush uncertainty', () => {
       SECP_SIGNED_MESSAGE,
       'mainnet',
       submit,
+      PERSIST_LOCAL_CID,
     );
 
     await expect(submission).rejects.toMatchObject({
@@ -216,7 +240,12 @@ describe('native Filecoin MpoolPush uncertainty', () => {
     });
 
     await expect(
-      submitSignedNativeFilecoinMessage(SECP_SIGNED_MESSAGE, 'mainnet', submit),
+      submitSignedNativeFilecoinMessage(
+        SECP_SIGNED_MESSAGE,
+        'mainnet',
+        submit,
+        PERSIST_LOCAL_CID,
+      ),
     ).rejects.toMatchObject({
       name: 'NativeFilecoinSubmissionUncertainError',
       cid: SECP_SIGNED_MESSAGE_CID,
@@ -239,7 +268,12 @@ describe('native Filecoin MpoolPush uncertainty', () => {
     });
 
     await expect(
-      submitSignedNativeFilecoinMessage(SECP_SIGNED_MESSAGE, 'mainnet', submit),
+      submitSignedNativeFilecoinMessage(
+        SECP_SIGNED_MESSAGE,
+        'mainnet',
+        submit,
+        PERSIST_LOCAL_CID,
+      ),
     ).rejects.toMatchObject({
       name: 'NativeFilecoinSubmissionUncertainError',
       cid: SECP_SIGNED_MESSAGE_CID,
@@ -262,7 +296,12 @@ describe('native Filecoin MpoolPush uncertainty', () => {
     });
 
     await expect(
-      submitSignedNativeFilecoinMessage(SECP_SIGNED_MESSAGE, 'mainnet', submit),
+      submitSignedNativeFilecoinMessage(
+        SECP_SIGNED_MESSAGE,
+        'mainnet',
+        submit,
+        PERSIST_LOCAL_CID,
+      ),
     ).rejects.toBe(rejected);
   });
 
@@ -282,7 +321,12 @@ describe('native Filecoin MpoolPush uncertainty', () => {
     });
 
     await expect(
-      submitSignedNativeFilecoinMessage(SECP_SIGNED_MESSAGE, 'mainnet', submit),
+      submitSignedNativeFilecoinMessage(
+        SECP_SIGNED_MESSAGE,
+        'mainnet',
+        submit,
+        PERSIST_LOCAL_CID,
+      ),
     ).rejects.toMatchObject({
       name: 'NativeFilecoinSubmissionUncertainError',
       cid: SECP_SIGNED_MESSAGE_CID,
@@ -298,6 +342,7 @@ describe('native Filecoin MpoolPush uncertainty', () => {
       SECP_SIGNED_MESSAGE,
       'mainnet',
       submit,
+      PERSIST_LOCAL_CID,
     );
 
     await expect(submission).rejects.toEqual(

--- a/src/lib/senders/nativeFilecoinProvider.ts
+++ b/src/lib/senders/nativeFilecoinProvider.ts
@@ -1,4 +1,4 @@
-import { getBalance } from '../DataProvider';
+import { getBalance, submitTransaction } from '../DataProvider';
 import type { FilecoinMessage, SignedMessage } from '../DataProvider/types';
 import {
   getDefaultNetworkKey,
@@ -275,7 +275,7 @@ function createIsoWalletProvider({
       return submitSignedNativeFilecoinMessage(
         signedMessage,
         account.networkKey,
-        undefined,
+        submitTransaction,
         submissionOptions,
       );
     },

--- a/src/lib/senders/nativeFilecoinSubmission.ts
+++ b/src/lib/senders/nativeFilecoinSubmission.ts
@@ -1,7 +1,6 @@
 import { Buffer as BrowserBuffer } from 'buffer';
 import { Message } from 'iso-filecoin/message';
 import { lotusCid } from 'iso-filecoin/utils';
-import { submitTransaction } from '../DataProvider';
 import { RpcProviderError } from '../DataProvider/RpcProviderError';
 import type { SignedMessage } from '../DataProvider/types';
 import type { SendFilNetworkKey } from '../networks';
@@ -197,11 +196,11 @@ function isAmbiguousMpoolFailure(error: unknown): boolean {
 export async function submitSignedNativeFilecoinMessage(
   signedMessage: SignedMessage,
   networkKey: SendFilNetworkKey,
-  submit: SubmitSignedMessage = submitTransaction,
-  options: NativeFilecoinSubmissionOptions = {},
+  submit: SubmitSignedMessage,
+  options: NativeFilecoinSubmissionOptions,
 ): Promise<NativeFilecoinSendResult> {
   const cid = computeSignedMessageCid(signedMessage);
-  await options.onCidComputed?.(cid);
+  await options.onCidComputed(cid);
   let response: { '/': string };
 
   try {

--- a/src/lib/senders/types.ts
+++ b/src/lib/senders/types.ts
@@ -4,7 +4,6 @@ import type {
   SendFilNetworkConfig,
   SendFilNetworkKey,
 } from '../networks';
-import type { PreparedBatchExecution } from '../transaction/batchExecution';
 
 export type ConnectedSenderKind = 'evm' | 'native-filecoin';
 export type SenderProviderKind = 'evm-wallet' | 'native-filecoin-wallet';
@@ -74,17 +73,17 @@ export type NativeFilecoinProviderSupportStatus =
   | 'not-detected'
   | 'not-supported';
 
-export interface NativeFilecoinBatchSigningRequest {
-  sender: NativeFilecoinConnectedSender;
-  preparedBatch: PreparedBatchExecution;
-}
-
 export interface NativeFilecoinSendResult {
   cid: string;
 }
 
 export interface NativeFilecoinSubmissionOptions {
-  onCidComputed?: (cid: string) => void | Promise<void>;
+  /**
+   * Must complete before the provider dispatches Filecoin.MpoolPush. Live
+   * callers use this boundary to persist the exact signed-message CID and
+   * block a second signature if the RPC response becomes ambiguous.
+   */
+  onCidComputed: (cid: string) => void | Promise<void>;
 }
 
 export interface NativeFilecoinWalletProvider {
@@ -97,9 +96,6 @@ export interface NativeFilecoinWalletProvider {
   checkSupport?: () => Promise<NativeFilecoinProviderSupportStatus>;
   signAndSubmitMessage?: (
     message: FilecoinMessage,
-    options?: NativeFilecoinSubmissionOptions,
-  ) => Promise<NativeFilecoinSendResult>;
-  signAndSubmitBatch?: (
-    request: NativeFilecoinBatchSigningRequest,
+    options: NativeFilecoinSubmissionOptions,
   ) => Promise<NativeFilecoinSendResult>;
 }

--- a/src/lib/transaction/__tests__/useExecuteNativeBatch.test.tsx
+++ b/src/lib/transaction/__tests__/useExecuteNativeBatch.test.tsx
@@ -652,17 +652,17 @@ describe('useExecuteNativeBatch', () => {
     expect(pollMessageStatus).not.toHaveBeenCalled();
   });
 
-  it('removes a pre-push CID lock after a definitive RPC rejection', async () => {
+  it('keeps a computed CID locked when the provider throws a plain post-CID error', async () => {
     const sender = getNativeSender();
     const provider = getProvider(10n ** 30n);
     const storage = dom.window.localStorage;
+    const confirmation = createDeferred<TransactionStatus>();
+    const pollMessageStatus = vi.fn(() => confirmation.promise);
 
     vi.mocked(provider.signAndSubmitMessage!).mockImplementation(
       async (_message, options) => {
         await options?.onCidComputed?.(CID);
-        throw new Error(
-          'Lotus RPC Filecoin.MpoolPush rejected the signed message: invalid nonce',
-        );
+        throw new TypeError('Failed to fetch after Filecoin.MpoolPush');
       },
     );
 
@@ -671,20 +671,45 @@ describe('useExecuteNativeBatch', () => {
       provider,
       rpc: getRpc(),
       storage,
-      pollMessageStatus: vi.fn(),
+      pollMessageStatus,
     });
+
+    let first!: Promise<string>;
+    await act(async () => {
+      first = latestHook!.executeBatch(recipients, 'ATOMIC');
+      await expect(first).resolves.toBe(CID);
+    });
+
+    expect(readNativeSubmissionRecords(storage).records).toEqual([
+      expect.objectContaining({ cid: CID, identity: getStoredNativeBatch().identity }),
+    ]);
+    expect(latestHook?.isIdentityLocked).toBe(true);
+    expect(latestHook?.isWalletMutationUnsafe).toBe(false);
+    expect(latestHook?.txHash).toBe(CID);
+    expect(latestHook?.submissionSnapshot).toMatchObject({ cid: CID });
+    expect(pollMessageStatus).toHaveBeenCalledWith(CID, 60, 5000, 'calibration');
+
+    expect(latestHook!.executeBatch(recipients, 'ATOMIC')).toBe(first);
+    expect(provider.signAndSubmitMessage).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      await expect(latestHook!.executeBatch(recipients, 'ATOMIC')).rejects.toMatchObject({
-        category: 'RPC_FAILURE',
+      confirmation.resolve({
+        cid: CID,
+        status: 'failed',
+        error: 'confirmation is still unavailable',
       });
+      await confirmation.promise;
+      await Promise.resolve();
     });
 
-    expect(readNativeSubmissionRecords(storage).records).toEqual([]);
-    expect(latestHook?.isIdentityLocked).toBe(false);
-    expect(latestHook?.isWalletMutationUnsafe).toBe(false);
-    expect(latestHook?.txHash).toBeUndefined();
-    expect(latestHook?.submissionSnapshot).toBeUndefined();
+    expect(latestHook?.state).toBe('failed');
+    expect(latestHook?.error).toMatchObject({
+      title: 'Native batch confirmation is uncertain',
+      recoverable: false,
+    });
+    expect(readNativeSubmissionRecords(storage).records).toHaveLength(1);
+    expect(latestHook!.executeBatch(recipients, 'ATOMIC')).toBe(first);
+    expect(provider.signAndSubmitMessage).toHaveBeenCalledTimes(1);
   });
 
   it('rechecks an in-memory CID when the post-Mpool fallback storage write failed', async () => {

--- a/src/lib/transaction/useExecuteNativeBatch.ts
+++ b/src/lib/transaction/useExecuteNativeBatch.ts
@@ -723,30 +723,15 @@ export function useExecuteNativeBatch({
                 );
                 lockedCid = submission.cid;
               } catch (cause) {
-                if (!isNativeFilecoinSubmissionUncertainError(cause)) {
-                  if (persistedCid) {
-                    const cleanupError = removeNativeSubmissionRecord(
-                      executionIdentity,
-                      persistedCid,
-                      storage,
-                    );
-
-                    if (cleanupError) {
-                      throw createNativeSubmissionStorageError(
-                        cleanupError,
-                        errorMode,
-                      );
-                    }
-
-                    setSubmissionSnapshot(undefined);
-                    setTxHash(undefined);
-                  }
-
+                if (persistedCid) {
+                  lockedCid = persistedCid;
+                  lockedSubmissionWasUncertain = true;
+                } else if (isNativeFilecoinSubmissionUncertainError(cause)) {
+                  lockedCid = cause.cid;
+                  lockedSubmissionWasUncertain = true;
+                } else {
                   throw cause;
                 }
-
-                lockedCid = cause.cid;
-                lockedSubmissionWasUncertain = true;
               }
 
               if (!persistedCid) {


### PR DESCRIPTION
## Summary

This hardens SendFIL's existing native Filecoin submission and recovery path against the incident class where a signed message is accepted by Lotus, the RPC response is lost or misleading, and the UI allows a fresh transaction to be signed.

- quarantines the retired Mainnet `https://rpc.node.glif.io/rpc/v1` fallback, including legacy configuration aliases and URL variants
- preserves the rule that the independent read-only fallback can never receive `Filecoin.MpoolPush`
- makes the locally derived CID persistence callback mandatory and awaits it before submission in the shipped FilSnap/Ledger provider
- treats every exception after a CID has been computed and persisted as an uncertain submission, regardless of JavaScript error class
- retains the exact-CID recovery lock and reconciles that CID for native batch, multisig Propose, Create, Approve, and Cancel
- saves a confirmed newly created multisig before clearing its recovery lock
- changes known-CID UI states to say the message may still execute and offer status recheck instead of a fresh submission
- documents the fail-closed invariants and adds focused fault-injection coverage

## Why

The live-test incident produced three separately signed, semantically identical 0.695 FIL messages with consecutive nonces 33, 34, and 35. All three executed. That rules out a harmless same-CID rebroadcast: the UI's retries authorized new spends after earlier outcomes were ambiguous.

The required native safety ordering is now:

1. sign the message
2. derive its exact CID locally
3. persist that CID while holding the origin-wide signer lock
4. submit the signed bytes
5. after any post-CID error, reconcile only that exact CID and never authorize a fresh signature

## Verification

- `yarn ci:verify`
  - lint passed
  - TypeScript passed
  - 40 test files / 466 tests passed
  - production build passed
- `env CI=1 yarn test:e2e:smoke`
  - 5 / 5 smoke tests passed
- focused native/RPC fault-injection review
  - plain `Error` and `TypeError` after CID persistence
  - remount/re-entry blocking and one-signature assertions
  - multisig actor-storage failure
  - retired-fallback and read-only submission routing
- two independent adversarial reviews found no release-blocking defect in the native/Lotus scope

## Scope and limits

This is deliberately a client-side **native Filecoin submission safety** PR.

- no executor contract, new smart contract, or contract architecture changes
- no change to transaction value-routing semantics
- the separate EVM/wagmi submission lane is not made duplicate-proof by this PR and needs its own response-loss design
- recovery remains browser-local, so stale deployed bundles, cleared browser storage, and another device remain operational boundaries
- the fail-closed choice can retain a recovery lock after a definitive post-CID protocol rejection; that favors preventing duplicate value transfer over automatic retry